### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actionsupdate.yml
+++ b/.github/workflows/actionsupdate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.3.0
 
     - name: Sync labels
-      uses: crazy-max/ghaction-github-labeler@v4
+      uses: crazy-max/ghaction-github-labeler@v4.1.0
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         yaml-file: .github/labels.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 2
 
@@ -73,7 +73,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
-        uses: release-drafter/release-drafter@v5.22.0
+        uses: release-drafter/release-drafter@v5.23.0
         with:
           publish: ${{ steps.check-version.outputs.tag != '' }}
           tag: ${{ steps.check-version.outputs.tag }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.5.0
@@ -65,7 +65,7 @@ jobs:
               fout.write("result={}\n".format(result))
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3.2.5
+        uses: actions/cache@v3.2.6
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit
@@ -79,14 +79,14 @@ jobs:
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
-        uses: "actions/upload-artifact@v3"
+        uses: "actions/upload-artifact@v3.1.2"
         with:
           name: coverage-data
           path: ".coverage.*"
 
       - name: Upload documentation
         if: matrix.session == 'docs-build'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: docs
           path: docs/_build
@@ -96,7 +96,7 @@ jobs:
     needs: tests
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4.5.0
@@ -132,4 +132,4 @@ jobs:
           nox --force-color --session=coverage -- xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[release-drafter/release-drafter](https://github.com/release-drafter/release-drafter)** published a new release **[v5.23.0](https://github.com/release-drafter/release-drafter/releases/tag/v5.23.0)** on 2023-02-21T09:25:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.2](https://github.com/actions/upload-artifact/releases/tag/v3.1.2)** on 2023-01-06T14:29:05Z
* **[crazy-max/ghaction-github-labeler](https://github.com/crazy-max/ghaction-github-labeler)** published a new release **[v4.1.0](https://github.com/crazy-max/ghaction-github-labeler/releases/tag/v4.1.0)** on 2022-10-18T20:17:22Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1)** on 2022-09-19T15:25:54Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.2.6](https://github.com/actions/cache/releases/tag/v3.2.6)** on 2023-02-21T10:18:08Z
