### PR TITLE
simplecas: add diff with forward accumulation

### DIFF
--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -16,6 +16,7 @@ from protosym.simplecas import sin
 from protosym.simplecas import Symbol
 from protosym.simplecas import x
 from protosym.simplecas import y
+from protosym.simplecas import zero
 
 
 two = Integer(2)
@@ -192,7 +193,7 @@ def test_simplecas_eval_f64() -> None:
     assert one.eval_f64() == 1.0
 
 
-def test_count_ops() -> None:
+def test_simplecas_count_ops() -> None:
     """Test count_ops_graph and count_ops_tree."""
 
     def make_expression(n: int) -> Expr:
@@ -215,3 +216,17 @@ def test_count_ops() -> None:
     for expr, ops_graph, ops_tree in test_cases:
         assert expr.count_ops_graph() == ops_graph
         assert expr.count_ops_tree() == ops_tree
+
+
+def test_simplecas_differentation() -> None:
+    """Test derivatives of simplecas expressions."""
+    assert one.diff(x) == zero
+    assert x.diff(x) == one
+    assert sin(1).diff(x) == zero
+    assert (2 * sin(x)).diff(x) == 2 * cos(x)
+    assert (x**3).diff(x) == 3 * x ** (Add(3, -1))
+    assert sin(x).diff(x) == cos(x)
+    assert cos(x).diff(x) == -sin(x)
+    assert (sin(x) + cos(x)).diff(x) == cos(x) + -1 * sin(x)
+    assert (sin(x) ** 2).diff(x) == 2 * sin(x) ** Add(2, -1) * cos(x)
+    assert (x * sin(x)).diff(x) == 1 * sin(x) + x * cos(x)


### PR DESCRIPTION
CC @brocksam

Adds differentiation using forward accumulation to simplecas.

I am not entirely happy with this because it blurs the line between what should be in the core (the differentiation algorithm and graph manipulation) and what should be in simplecas (the definitions of Add, Mul, etc).

One thing I had considered was maybe adding a differentiation context like:
```python
from core import DiffRules, _diff

ctx = DiffRules(Add, Mul, Pow, one, zero)
ctx.add_rule(sin, cos)
ctx.add_rule(cos, lambda e: -sin(e))

def diff(expr: Expr, sym: Expr) -> Expr:
    return _diff(expr.rep, sym.rep, ctx)
```
Or perhaps even it's just a `Differentiator` class to complement the `Evaluator` class like:
```python
from core import Differentiator

_diff = Differentiator(Add, Mul, Pow, one, zero)
_diff.add_rule(sin, cos)
_diff.add_rule(cos, lambda e: -sin(e))

def diff(expr: Expr, sym: Expr) -> Expr:
    return Expr(_diff(expr.rep, sym.rep))
```
For now I'd just suggest that we merge this in so at least the functionality is there can be tested for performance etc. His a quick benchmark:
```python
In [2]: from sympy import *

In [3]: x = symbols('x')

In [4]: %time e = sin(sin(sin(sin(sin(sin(x)))))).diff(x)
CPU times: user 28 ms, sys: 4 ms, total: 32 ms
Wall time: 32.8 ms

In [5]: %time e.evalf(subs={x:1})
CPU times: user 4 ms, sys: 0 ns, total: 4 ms
Wall time: 6.47 ms
Out[5]: 0.138774896812591

In [6]: from symengine import *

In [7]: x = symbols('x')

In [8]: %time e = sin(sin(sin(sin(sin(sin(x)))))).diff(x)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 218 µs

In [10]: %time e.subs(x, 1).evalf()
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 368 µs
Out[10]: 0.138774896812591

In [11]: from protosym.simplecas import *

In [12]: x = Symbol('x')

In [13]: %time e = sin(sin(sin(sin(sin(sin(x)))))).diff(x)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 691 µs

In [14]: %time e.eval_f64({x:1.0})
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 286 µs
Out[14]: 0.13877489681259078
```
Then a larger example (too slow with SymPy):
```python
In [18]: from symengine import *

In [19]: x = symbols('x')

In [20]: %time e = sin(sin(sin(sin(sin(sin(x)))))).diff(x, 10)
CPU times: user 392 ms, sys: 8 ms, total: 400 ms
Wall time: 397 ms

In [21]: %time e.subs(x, 1).evalf()
CPU times: user 232 ms, sys: 0 ns, total: 232 ms
Wall time: 234 ms
Out[21]: 11560.616267597

In [22]: from protosym.simplecas import *

In [23]: %time e = sin(sin(sin(sin(sin(sin(x)))))).diff(x, 10)
CPU times: user 108 ms, sys: 0 ns, total: 108 ms
Wall time: 108 ms

In [24]: %time e.eval_f64({x:1.0})
CPU times: user 16 ms, sys: 0 ns, total: 16 ms
Wall time: 15.5 ms
Out[24]: 11560.616267596995
```