### PR TITLE
feat: Add Transformer class and bin_expand function

### DIFF
--- a/src/protosym/core/exceptions.py
+++ b/src/protosym/core/exceptions.py
@@ -1,0 +1,11 @@
+"""Module for all protosym exceptions."""
+
+
+class ProtoSymError(Exception):
+    """Superclass for all protosym exceptions."""
+
+
+class NoEvaluationRuleError(ProtoSymError):
+    """Raised when an :class:`Evaluator` has no rule for an expression."""
+
+    pass

--- a/src/protosym/core/exceptions.py
+++ b/src/protosym/core/exceptions.py
@@ -4,6 +4,8 @@
 class ProtoSymError(Exception):
     """Superclass for all protosym exceptions."""
 
+    pass
+
 
 class NoEvaluationRuleError(ProtoSymError):
     """Raised when an :class:`Evaluator` has no rule for an expression."""

--- a/tests/core/test_evaluate.py
+++ b/tests/core/test_evaluate.py
@@ -5,7 +5,9 @@ from pytest import raises
 
 from protosym.core.atom import AtomType
 from protosym.core.evaluate import Evaluator
+from protosym.core.evaluate import Transformer
 from protosym.core.exceptions import NoEvaluationRuleError
+from protosym.core.tree import funcs_symbols
 from protosym.core.tree import TreeAtom
 from protosym.core.tree import TreeExpr
 
@@ -56,9 +58,6 @@ def test_Evaluator() -> None:
 
 def test_Transformer() -> None:
     """Test defining and using a Transformer."""
-    from protosym.core.tree import funcs_symbols
-    from protosym.core.evaluate import Evaluator, Transformer
-
     [f, g], [x, y] = funcs_symbols(["f", "g"], ["x", "y"])
 
     f2g = Transformer()


### PR DESCRIPTION
There are several things mixed up here:

- Add a `bin_expand` method to `Expr`.
- Make a new class `Transformer` as an alternative to `Evaluator`
- Small refactor of `Evaluator` to have an `eval_atom` method and rename `call` to `eval_operation`.
- Add a `protosym.core/exceptions` module to define exception types.
- Add an XFAIL test for printing `f(x)` in `simplecas`.

A precursor to adding lambdify with LLVM is having a `bin_expand` method that can turn an associative operation into a sequence of binary operations e.g. `(x + y + z)` -> `((x + y) + z)`. This is because LLVM IR only defines binary operations. Actually it is currently difficult in protosym to create a flattened `Add` like `(x + y + z)` because no `flatten` function is provided and all natural operations like `+` will give unflattened expressions consisting of binary operations. An expression converted from SymPy for example will have associative operations though:
```python
In [1]: from protosym.simplecas import *

In [2]: x + y + x
Out[2]: ((x + y) + x)

In [3]: from sympy.abc import a, b, c

In [4]: Expr.from_sympy(a + b + c)
Out[4]: (a + b + c)

In [5]: type(_)
Out[5]: protosym.simplecas.Expr
```
Likewise when parsing is added I would want `parse('x + y + z')` to give a flattened `Add`.

When writing the `bin_expand` function I realised that it is quite awkward to do with `Evaluator` because `Evaluator` requires defining rules for all atoms and heads. In the case of `bin_expand` we only want to modify `Add ` and `Mul` and leave all other expressions unchanged but we don't want to have to list rules for all of the expression types that we *don't* want to change. For this I added a `Transformer` class as a subclass of `Evaluator`, A `Transformer` is for converting a `TreeExpr` nto another `TreeExpr` and allows any atoms or heads without rules to pass through unmodified. See the tests and doctests for examples comparing this with `Evaluator`.

I also discovered that in simplecas this fails and added an XFAIL test for it:
```python
In [5]: from protosym.simplecas import *

In [6]: f = Function('f')

In [7]: print(f(x))
---------------------------------------------------------------------------
KeyError: TreeAtom(Function('f'))
```
This is somewhat similar to the `bin_expand/Evaluator` issue. Basically there are printing rules for `f` as an atom:
```python
In [9]: print(f)
f
```
However when `f` is a head as in `f(x)` the evaluator expects a rule for each head like a rule for `sin(...)` and ` rule for `cos(...)`. There needs to be a way to give a default rule for the case when there is not a rule for the given head.

I think that it is always good practice to have an exceptions module that downstream code can import from and look in to see all of the possible exceptions so I've added that. Currently we have
```console
$ git grep 'raise '
noxfile.py:    raise SystemExit(dedent(message)) from None
src/protosym/core/evaluate.py:            raise NoEvaluationRuleError(msg)
src/protosym/simplecas.py:        raise ExpressifyError
src/protosym/simplecas.py:            raise TypeError("First argument to Expr should be TreeExpr")
src/protosym/simplecas.py:    raise NotImplementedError("Cannot convert " + type(expr).__name__)
```
Perhaps the other exceptions raised should be changed to use something other than `TypeError` and `NotImplementedError`. I think it is generally good not to reuse exception types that are already used in other places because then someone trying to catch exceptions can catch the wrong one. Ideally an exception class should be used to identify a clear scope in the code for where the exception comes from if it is caught anywhere.