### PR TITLE
feat: add generic rule handlers to Evaluator

### DIFF
--- a/src/protosym/core/evaluate.py
+++ b/src/protosym/core/evaluate.py
@@ -85,7 +85,7 @@ class Evaluator(Generic[_T]):
     >>> expr2 = cos(x)
     >>> print(expr2)
     cos(x)
-    >>> evalf(expr2, {x:1.0})
+    >>> evalf(expr2, {x: 1.0})
     0.5403023058681398
     """
 
@@ -240,7 +240,7 @@ class Transformer(Evaluator[TreeExpr]):
     >>> expr = f(g(x, f(y)), y)
     >>> f2g_eval = Evaluator[TreeExpr]()
     >>> f2g_eval.add_opn(f, lambda args: g(*args))
-    >>> f2g_eval(expr) # doctest: +NORMALIZE_WHITESPACE
+    >>> f2g_eval(expr)  # doctest: +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
         ...
     protosym.core.exceptions.NoEvaluationRuleError: No rule for atom:
@@ -250,7 +250,7 @@ class Transformer(Evaluator[TreeExpr]):
     rule for ``g``:
 
     >>> f2g_eval.add_atom_generic(str)
-    >>> f2g_eval(expr) # doctest: +NORMALIZE_WHITESPACE
+    >>> f2g_eval(expr)  # doctest: +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
         ...
     protosym.core.exceptions.NoEvaluationRuleError: No rule for head:

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest import raises
 from pytest import skip
 
@@ -8,7 +7,7 @@ from protosym.simplecas import Expr
 from protosym.simplecas import ExprAtomType
 from protosym.simplecas import expressify
 from protosym.simplecas import ExpressifyError
-from protosym.simplecas import Function
+from protosym.simplecas import f
 from protosym.simplecas import Integer
 from protosym.simplecas import Mul
 from protosym.simplecas import negone
@@ -22,7 +21,6 @@ from protosym.simplecas import zero
 
 
 two = Integer(2)
-f = Function("f")
 
 
 def test_simplecas_types() -> None:
@@ -110,6 +108,7 @@ def test_simplecas_repr() -> None:
     assert str(y) == "y"
     assert str(f) == "f"
     assert str(sin) == "sin"
+    assert str(f(x)) == "f(x)"
     assert str(sin(cos(x))) == "sin(cos(x))"
     assert str(x + y) == "(x + y)"
     assert str(one + two) == "(1 + 2)"
@@ -118,25 +117,11 @@ def test_simplecas_repr() -> None:
     assert str(x + x + x) == "((x + x) + x)"
 
 
-@pytest.mark.xfail
-def test_simplecas_repr_xfail() -> None:
-    """Test printing an undefined function."""
-    #
-    # This fails because Evaluator expects every function to be defined. There
-    # is a printing rule for Function but that only handles an uncalled
-    # function like f rather than f(x). There needs to be a way to give a
-    # default rule to an Evaluator for handling the cases where there is no
-    # operation rule defined for the head.
-    #
-    assert str(f(x)) == "f(x)"
-    assert repr(f(x)) == "f(x)"
-    assert f(x).eval_latex() == "f(x)"
-
-
 def test_simplecas_latex() -> None:
     """Test basic operations with simplecas."""
     assert x.eval_latex() == r"x"
     assert y.eval_latex() == r"y"
+    assert f(x).eval_latex() == "f(x)"
     assert sin(x).eval_latex() == r"\sin(x)"
     assert sin(cos(x)).eval_latex() == r"\sin(\cos(x))"
     assert (x + y).eval_latex() == r"(x + y)"


### PR DESCRIPTION
Following gh-30 and specifically https://github.com/oscarbenjamin/protosym/pull/30#issuecomment-1448202601

This adds two new methods `add_atom_generic` and `add_op_generic` to `Evaluator` so that generic fallback rules can be supplied for atoms or heads that do not have specific rules associated with them.

That fixes the bug with printing `f(x)`:
```python
In [1]: from protosym.simplecas import *

In [2]: f(x)
Out[2]: f(x)
```

It also means that `Transformer` is perhaps not needed since its functionality is just equivalent to adding generic rules to an Evaluator. For now I left it there just to show that it is equivalent. I do think that `TreeExpr->TreeExpr` rules will be very common so it does perhaps make sense to keep `Transformer`...

The generic rules also made it possible to simplify `count_ops_tree` since it only needs the two generic rules. That also suggests that it is a good idea to have them.

Possibly it would make sense to be able to provide the generic rules in the constructor like:
```python
count_ops_tree = Evaluator[int](
    lambda a: 1,
    lambda h, cnts: 1 + sum(cnts)
)
```
The reason that it does not currently work that for adding operators and instead uses `add_atom` and `add_op1` etc is just because there is otherwise no way to make it consistent in terms of types. The `add_atom` method takes a `Callable[[_S], _T]` and for different `_S` those are not consistent. Likewise `add_op1` takes `Callable[[_T], _T]` and `add_op2` takes `Callable[[_T, _T], _T]` etc. Forcing them to be passed in separate calls allows the typechecker to match up the `_S` and `_T` across all of the parameters. Internally Evaluator buries all of these callbacks in a dict with Any/ignore but at least externally it has a typed interface.