### PR TITLE
feat: add to_llvm_ir and lambdify

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -141,7 +141,7 @@ def mypy(session: Session) -> None:
 @session(python=python_versions)
 def tests(session: Session) -> None:
     """Run the test suite."""
-    session.install(".", "sympy")
+    session.install(".", "sympy", "llvmlite")
     session.install("coverage[toml]", "pytest", "pygments")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
@@ -179,7 +179,7 @@ def coverage(session: Session) -> None:
 def xdoctest(session: Session) -> None:
     """Run examples with xdoctest."""
     args = session.posargs or ["all"]
-    session.install(".", "sympy")
+    session.install(".", "sympy", "llvmlite")
     session.install("xdoctest[colors]")
     session.run("python", "-m", "xdoctest", "--quiet", package, *args)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1923,6 +1923,44 @@ virtualenv = ">=14"
 tox-to-nox = ["jinja2", "tox"]
 
 [[package]]
+name = "numpy"
+version = "1.24.2"
+description = "Fundamental package for array computing in Python"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "numpy-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978"},
+    {file = "numpy-1.24.2-cp310-cp310-win32.whl", hash = "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9"},
+    {file = "numpy-1.24.2-cp310-cp310-win_amd64.whl", hash = "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910"},
+    {file = "numpy-1.24.2-cp311-cp311-win32.whl", hash = "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95"},
+    {file = "numpy-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96"},
+    {file = "numpy-1.24.2-cp38-cp38-win32.whl", hash = "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d"},
+    {file = "numpy-1.24.2-cp38-cp38-win_amd64.whl", hash = "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780"},
+    {file = "numpy-1.24.2-cp39-cp39-win32.whl", hash = "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468"},
+    {file = "numpy-1.24.2-cp39-cp39-win_amd64.whl", hash = "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f"},
+    {file = "numpy-1.24.2.tar.gz", hash = "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22"},
+]
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -3166,6 +3204,56 @@ files = [
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
+name = "symengine"
+version = "0.9.2"
+description = "Python library providing wrappers to SymEngine"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4"
+files = [
+    {file = "symengine-0.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c57b542a88d88bf716f2ac15b928d37587030d5347d45aa3af18c741c07e04e2"},
+    {file = "symengine-0.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:201a6c33a2c391d4b9350e9f171e05ca54011599bb9fa9cd188548f0a26d2f31"},
+    {file = "symengine-0.9.2-cp310-cp310-manylinux2010_x86_64.whl", hash = "sha256:dee0df899abeb78c08fff6471f4d979dad7d3d235e00303c7a641da7b92b025b"},
+    {file = "symengine-0.9.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:dfb3c764a52f2ade33c90c64baa14175103b6527773f2e23c961906159515725"},
+    {file = "symengine-0.9.2-cp310-cp310-manylinux2014_ppc64le.whl", hash = "sha256:2ca84ce89c27788e9675fad31c8fa05317acd7ec7e034b562f3d3a6e72bf8004"},
+    {file = "symengine-0.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:eaf3604c469af16c1aa9d8f4287295e616840d7d14eeaab13228dd11c5e5fe75"},
+    {file = "symengine-0.9.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:78c116c6220baf3c0fa93858e965db44661455e5f8d34558fef649b7c7be5e57"},
+    {file = "symengine-0.9.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:467621288f51f0315f5fc079e6919fad501faa99a5ed65c1f46197dc1be7fa47"},
+    {file = "symengine-0.9.2-cp311-cp311-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d6d92b02d2e72137d63520c4a2326ff4e1c1c24724160bd31e7f7370ad94185"},
+    {file = "symengine-0.9.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:061e045b9fef170b1f11a6f1c9aa387ec44d60480988a0af91ed26c96fb9427b"},
+    {file = "symengine-0.9.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:438b04f7089993caef00839a1e926f8b32cee77d7fb1f0e0d7cc69c351d16c08"},
+    {file = "symengine-0.9.2-cp311-cp311-win_amd64.whl", hash = "sha256:376f74c0885b2f041fc08c00b63aae1c6732804da7a591d658a82ba1b70f2167"},
+    {file = "symengine-0.9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4bd4e32bd3208477e5da0fa1c0a23f1f54c32bfc9d4fa25c433af03dfbb92342"},
+    {file = "symengine-0.9.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:dd2b06fcb133bbbb41428a94c6c07f8f151a02c18deb26382b7e878a808971ba"},
+    {file = "symengine-0.9.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:aa6e193701d244e49a141782cd87248c00d78cff398cd395d46db632bec41cf4"},
+    {file = "symengine-0.9.2-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:eb4be488f1a8d9a04c813af342ab5c8cb69a7d0898df6619f67a4eafad722d2a"},
+    {file = "symengine-0.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:e70728b93653c1787267e300d05ee696e067bc324d58ac0858d744c71a14e648"},
+    {file = "symengine-0.9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f6907a6b306d0b485d210557f99f1c2fbcba83aba88da5ec9b84a0a3f34165f8"},
+    {file = "symengine-0.9.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:05608329bfb776de1390bb7981c074f866157792a7b4e2af60073b790e051520"},
+    {file = "symengine-0.9.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:51d590cb488e7ff05e96896baa555f41feee0eec1cafb43756b46b966fb2eb57"},
+    {file = "symengine-0.9.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:690f84811812ae5502c0852cad3a60dae9a9b45874f71caafe90b0bd3e6f887c"},
+    {file = "symengine-0.9.2-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:a54aa2151b09ef4460d9142446d5404adb4c01ef8107d4060a7dc8673ca93cc4"},
+    {file = "symengine-0.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:b97d6005c528a1935ad15c661f262e525f12dfb707ea30d2af32397ba534387b"},
+    {file = "symengine-0.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fdea89508505882e2c7a802836810b552e7b79e73ff5daf5f8f4dda95b79be83"},
+    {file = "symengine-0.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ee122c716be397cf455f01e90a731636d9f6389179b207737e99b91d5e0baa8a"},
+    {file = "symengine-0.9.2-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f709947e17c97e6ad18d6f4a2703b0360092d7193636f9a220a75b09ea262581"},
+    {file = "symengine-0.9.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0a46099e3c1ed27dbeac28f1318b2da030170a001f3672d34a39dc2966d4a180"},
+    {file = "symengine-0.9.2-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:614ac3807944c7ae3158f2a1600a31a3f6195b4b6805113f49352f52d2535082"},
+    {file = "symengine-0.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:add5dd16568a82fbf7c8ad8f68776040ece19a8f02380121a65c6610b5849ec1"},
+    {file = "symengine-0.9.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:516ce80e73de94e1952cdf8ecbb75c581c6512b61f05979b92d3ad09867663ed"},
+    {file = "symengine-0.9.2-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:0698bc5a95784f791feae5c6afbf49c4ccc2ce64531e4db505a2c0d1276fd015"},
+    {file = "symengine-0.9.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1bd97d07fb5b82965c60713407cc7f8145d62406185df812beb31150a3c29fd0"},
+    {file = "symengine-0.9.2-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5040bf8d1fc34d958a83299dcc8a529e5f66fda416fe8f405466e10b0cd8e553"},
+    {file = "symengine-0.9.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7670f0c305a404c70a757c1aa0d7a81dbd5693bd6a04345e470a7584f166d684"},
+    {file = "symengine-0.9.2-pp38-pypy38_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0bdf6102e01e1f81eca818d1ff538b100fa9462f30aa050ca4bb3246cb4874aa"},
+    {file = "symengine-0.9.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:1c2157602dc8b2ff6bfe6e9fdba7d527e674ebbeb73de1eb4fe197b3ddf226bb"},
+    {file = "symengine-0.9.2-pp39-pypy39_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6eeeb5adf713be620c80c9fc2c215fac51c971e2bd57982da60c6f791af63f96"},
+    {file = "symengine-0.9.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ccaeba9637c16e7a6b6443dfba36de99e6020ff5a4ca76c1a1710d43d04db7"},
+    {file = "symengine-0.9.2-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db8117e21bf73e0db144e060354cdbfb6b893e9125cf8fd43565e1546c186840"},
+    {file = "symengine-0.9.2.tar.gz", hash = "sha256:0f7e45f5bba3fa844f7de7aa8d6640faaacb1075df76d8e4996e82b0ec6a4f62"},
+]
+
+[[package]]
 name = "sympy"
 version = "1.11.1"
 description = "Computer algebra system (CAS) in Python"
@@ -3488,4 +3576,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "14283880398d0a1690f6d87a35e19db52977e88888fe9d20a28066286c2000d7"
+content-hash = "41f29fe4757e5ad721760a13e8861e16dbda2241103f0f7b7c9ae504aa344674"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1490,6 +1490,44 @@ six = "*"
 tornado = {version = "*", markers = "python_version > \"2.7\""}
 
 [[package]]
+name = "llvmlite"
+version = "0.39.1"
+description = "lightweight wrapper around basic LLVM functionality"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "llvmlite-0.39.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6717c7a6e93c9d2c3d07c07113ec80ae24af45cde536b34363d4bcd9188091d9"},
+    {file = "llvmlite-0.39.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ddab526c5a2c4ccb8c9ec4821fcea7606933dc53f510e2a6eebb45a418d3488a"},
+    {file = "llvmlite-0.39.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3f331a323d0f0ada6b10d60182ef06c20a2f01be21699999d204c5750ffd0b4"},
+    {file = "llvmlite-0.39.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2c00ff204afa721b0bb9835b5bf1ba7fba210eefcec5552a9e05a63219ba0dc"},
+    {file = "llvmlite-0.39.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16f56eb1eec3cda3a5c526bc3f63594fc24e0c8d219375afeb336f289764c6c7"},
+    {file = "llvmlite-0.39.1-cp310-cp310-win32.whl", hash = "sha256:d0bfd18c324549c0fec2c5dc610fd024689de6f27c6cc67e4e24a07541d6e49b"},
+    {file = "llvmlite-0.39.1-cp310-cp310-win_amd64.whl", hash = "sha256:7ebf1eb9badc2a397d4f6a6c8717447c81ac011db00064a00408bc83c923c0e4"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6546bed4e02a1c3d53a22a0bced254b3b6894693318b16c16c8e43e29d6befb6"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1578f5000fdce513712e99543c50e93758a954297575610f48cb1fd71b27c08a"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3803f11ad5f6f6c3d2b545a303d68d9fabb1d50e06a8d6418e6fcd2d0df00959"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50aea09a2b933dab7c9df92361b1844ad3145bfb8dd2deb9cd8b8917d59306fb"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-win32.whl", hash = "sha256:b1a0bbdb274fb683f993198775b957d29a6f07b45d184c571ef2a721ce4388cf"},
+    {file = "llvmlite-0.39.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e172c73fccf7d6db4bd6f7de963dedded900d1a5c6778733241d878ba613980e"},
+    {file = "llvmlite-0.39.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e31f4b799d530255aaf0566e3da2df5bfc35d3cd9d6d5a3dcc251663656c27b1"},
+    {file = "llvmlite-0.39.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:62c0ea22e0b9dffb020601bb65cb11dd967a095a488be73f07d8867f4e327ca5"},
+    {file = "llvmlite-0.39.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ffc84ade195abd4abcf0bd3b827b9140ae9ef90999429b9ea84d5df69c9058c"},
+    {file = "llvmlite-0.39.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c0f158e4708dda6367d21cf15afc58de4ebce979c7a1aa2f6b977aae737e2a54"},
+    {file = "llvmlite-0.39.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22d36591cd5d02038912321d9ab8e4668e53ae2211da5523f454e992b5e13c36"},
+    {file = "llvmlite-0.39.1-cp38-cp38-win32.whl", hash = "sha256:4c6ebace910410daf0bebda09c1859504fc2f33d122e9a971c4c349c89cca630"},
+    {file = "llvmlite-0.39.1-cp38-cp38-win_amd64.whl", hash = "sha256:fb62fc7016b592435d3e3a8f680e3ea8897c3c9e62e6e6cc58011e7a4801439e"},
+    {file = "llvmlite-0.39.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa9b26939ae553bf30a9f5c4c754db0fb2d2677327f2511e674aa2f5df941789"},
+    {file = "llvmlite-0.39.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e4f212c018db951da3e1dc25c2651abc688221934739721f2dad5ff1dd5f90e7"},
+    {file = "llvmlite-0.39.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39dc2160aed36e989610fc403487f11b8764b6650017ff367e45384dff88ffbf"},
+    {file = "llvmlite-0.39.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ec3d70b3e507515936e475d9811305f52d049281eaa6c8273448a61c9b5b7e2"},
+    {file = "llvmlite-0.39.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60f8dd1e76f47b3dbdee4b38d9189f3e020d22a173c00f930b52131001d801f9"},
+    {file = "llvmlite-0.39.1-cp39-cp39-win32.whl", hash = "sha256:03aee0ccd81735696474dc4f8b6be60774892a2929d6c05d093d17392c237f32"},
+    {file = "llvmlite-0.39.1-cp39-cp39-win_amd64.whl", hash = "sha256:3fc14e757bc07a919221f0cbaacb512704ce5774d7fcada793f1996d6bc75f2a"},
+    {file = "llvmlite-0.39.1.tar.gz", hash = "sha256:b43abd7c82e805261c425d50335be9a6c4f84264e34d6d6e475207300005d572"},
+]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.2"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -3450,4 +3488,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "cb0807ee8d7c6ec92b3727a1ad58bb1d67af1ca0cf1ecaf4f9eaca549862713c"
+content-hash = "14283880398d0a1690f6d87a35e19db52977e88888fe9d20a28066286c2000d7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ pytest-coverage = "^0.0"
 sympy = "^1.11.1"
 pip-upgrader = "^1.4.15"
 flake8-type-checking = "^2.3.0"
+llvmlite = "^0.39.1"
 
 
 [tool.poetry.group.utils.dependencies]
@@ -83,6 +84,8 @@ show_error_context = true
 [[tool.mypy.overrides]]
 module = [
     'jinja2',
+    'llvmlite',
+    'llvmlite.binding',
     'py',
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ sympy = "^1.11.1"
 pip-upgrader = "^1.4.15"
 flake8-type-checking = "^2.3.0"
 llvmlite = "^0.39.1"
+symengine = "^0.9.2"
+numpy = "^1.24.2"
 
 
 [tool.poetry.group.utils.dependencies]

--- a/src/protosym/simplecas.py
+++ b/src/protosym/simplecas.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+import struct
 from functools import reduce
 from functools import wraps
 from typing import Any
@@ -17,6 +18,7 @@ from weakref import WeakValueDictionary as _WeakDict
 from protosym.core.atom import AtomType
 from protosym.core.evaluate import Evaluator
 from protosym.core.evaluate import Transformer
+from protosym.core.exceptions import ProtoSymError
 from protosym.core.tree import forward_graph
 from protosym.core.tree import topological_sort
 from protosym.core.tree import TreeAtom
@@ -500,6 +502,31 @@ class Expr:
         """
         return Expr(bin_expand(self.rep))
 
+    def to_llvm_ir(self, symargs: list[Expr]) -> str:
+        """Return LLVM IR code evaluating this expression.
+
+        >>> from protosym.simplecas import sin, x
+        >>> expr = sin(x) + sin(sin(x))
+        >>> print(expr.to_llvm_ir([x]))
+        ; ModuleID = "mod1"
+        target triple = "unknown-unknown-unknown"
+        target datalayout = ""
+        <BLANKLINE>
+        declare double    @llvm.pow.f64(double %Val1, double %Val2)
+        declare double    @llvm.sin.f64(double %Val)
+        declare double    @llvm.cos.f64(double %Val)
+        <BLANKLINE>
+        define double @"jit_func1"(double %"x")
+        {
+        %".0" = call double @llvm.sin.f64(double %"x")
+        %".1" = call double @llvm.sin.f64(double %".0")
+        %".2" = fadd double %".0", %".1"
+        ret double %".2"
+        }
+
+        """
+        return _to_llvm_f64([arg.rep for arg in symargs], self.rep)
+
 
 # Avoid importing SymPy if possible.
 _eval_to_sympy: Evaluator[Any] | None = None
@@ -713,3 +740,80 @@ def _diff_forward(expression: TreeExpr, sym: TreeExpr) -> TreeExpr:
     # list of derivatives of every subexpression in expr. At the top of the
     # stack is expr and its derivative is at the top of diff_stack.
     return diff_stack[-1]
+
+
+# -------------------------------------------------
+# lambdification with LLVM
+# ------------------------------------------------
+
+
+class LLVMNotImplementedError(ProtoSymError):
+    """Raised when an operation is not supported for LLVM."""
+
+    pass
+
+
+def _double_to_hex(f: float) -> str:
+    return hex(struct.unpack("<Q", struct.pack("<d", f))[0])
+
+
+_llvm_header = """
+; ModuleID = "mod1"
+target triple = "unknown-unknown-unknown"
+target datalayout = ""
+
+declare double    @llvm.pow.f64(double %Val1, double %Val2)
+declare double    @llvm.sin.f64(double %Val)
+declare double    @llvm.cos.f64(double %Val)
+
+"""
+
+
+def _to_llvm_f64(symargs: list[TreeExpr], expression: TreeExpr) -> str:
+    """Code for LLVM IR function computing ``expression`` from ``symargs``."""
+    expression = bin_expand(expression)
+
+    graph = forward_graph(expression)
+
+    argnames = {s: f'%"{s}"' for s in symargs}  # noqa
+
+    identifiers = []
+    for a in graph.atoms:
+        if a in symargs:
+            identifiers.append(argnames[a])
+        elif isinstance(a, TreeAtom) and a.value.atom_type == Integer.atom_type:
+            identifiers.append(_double_to_hex(a.value.value))
+        else:
+            raise LLVMNotImplementedError("No LLVM rule for: " + repr(a))
+
+    args = ", ".join(f"double {argnames[arg]}" for arg in symargs)
+    signature = f'define double @"jit_func1"({args})'
+
+    instructions: list[str] = []
+    for func, indices in graph.operations:
+        n = len(instructions)
+        identifier = f'%".{n}"'
+        identifiers.append(identifier)
+        argids = [identifiers[i] for i in indices]
+
+        if func == Add.rep:
+            line = f"{identifier} = fadd double " + ", ".join(argids)
+        elif func == Mul.rep:
+            line = f"{identifier} = fmul double " + ", ".join(argids)
+        elif func == Pow.rep:
+            args = f"double {argids[0]}, double {argids[1]}"
+            line = f"{identifier} = call double @llvm.pow.f64({args})"
+        elif func == sin.rep:
+            line = f"{identifier} = call double @llvm.sin.f64(double {argids[0]})"
+        elif func == cos.rep:
+            line = f"{identifier} = call double @llvm.cos.f64(double {argids[0]})"
+        else:
+            raise LLVMNotImplementedError("No LLVM rule for: " + repr(func))
+
+        instructions.append(line)
+
+    instructions.append(f"ret double {identifiers[-1]}")
+
+    function_lines = [signature, "{", *instructions, "}"]
+    module_code = _llvm_header + "\n".join(function_lines)
+    return module_code

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -9,6 +9,7 @@ from protosym.simplecas import expressify
 from protosym.simplecas import ExpressifyError
 from protosym.simplecas import f
 from protosym.simplecas import Integer
+from protosym.simplecas import lambdify
 from protosym.simplecas import LLVMNotImplementedError
 from protosym.simplecas import Mul
 from protosym.simplecas import negone
@@ -275,3 +276,11 @@ ret double %".4"
 
     raises(LLVMNotImplementedError, lambda: f(x).to_llvm_ir([x]))
     raises(LLVMNotImplementedError, lambda: f(x).to_llvm_ir([]))
+
+
+def test_simplecas_lambdify_llvm() -> None:
+    """Test simplecas lambdify function for a simple expression."""
+    expr1 = sin(cos(x)) * x**2 + 1
+    val1 = expr1.eval_f64({x: 1.0})
+    f = lambdify([x], expr1)
+    assert f(1) == f(1.0) == val1


### PR DESCRIPTION
Adds the lambdify functions based on llvmlite to simplecas.

Quick benchmark with a large expression. This is SymEngine:
```python
In [10]: from symengine import *

In [11]: x = symbols('x')

In [12]: %time e = sin(sin(sin(sin(sin(sin(sin(x))))))).diff(x, 10)
CPU times: user 928 ms, sys: 8 ms, total: 936 ms
Wall time: 934 ms

In [13]: %time f = lambdify([x], [e], backend='llvm')
CPU times: user 35.8 s, sys: 168 ms, total: 36 s
Wall time: 35.9 s

In [14]: %time f(1)
CPU times: user 4 ms, sys: 0 ns, total: 4 ms
Wall time: 416 µs
Out[14]: array(55578.02833128)

In [15]: %timeit f(1)
88.9 µs ± 898 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
This is protosym:
```python
In [16]: from protosym.simplecas import *

In [17]: x = Symbol('x')

In [18]: %time e = sin(sin(sin(sin(sin(sin(sin(x))))))).diff(x, 10)
CPU times: user 168 ms, sys: 4 ms, total: 172 ms
Wall time: 174 ms

In [19]: %time f = lambdify([x], e)
CPU times: user 208 ms, sys: 4 ms, total: 212 ms
Wall time: 214 ms

In [20]: %time f(1)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 47.4 µs
Out[20]: 55578.028331281705

In [21]: %timeit f(1)
2.32 µs ± 16.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
Every part is faster in protosym:

1. Creating and differentiating the expression.
2. Calling lambdify.
3. Calling the lambdified function.

With smaller expressions SymEngine is faster for the first two steps but the timings are also quite close. The lambdified function always seems to be faster with protosym though which I think comes from building the function out of the graph form.

SymEngine (small expression):
```python
In [1]: from symengine import *

In [2]: x = Symbol('x')

In [3]: %time e = sin(sin(sin(x))).diff(x)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 244 µs

In [4]: %time f = lambdify([x], [e], backend='llvm')
CPU times: user 8 ms, sys: 0 ns, total: 8 ms
Wall time: 11.7 ms

In [5]: %time f(1)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 122 µs
Out[5]: array(0.26450827)

In [6]: %timeit f(1)
11.2 µs ± 45.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
Then protosym:
```python
In [10]: from protosym.simplecas import *

In [11]: x = Symbol('x')

In [12]: %time e = sin(sin(sin(x))).diff(x)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 749 µs

In [13]: %time f = lambdify([x], e)
CPU times: user 44 ms, sys: 4 ms, total: 48 ms
Wall time: 46.2 ms

In [14]: %time f(1)
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 42.4 µs
Out[14]: 0.26450827039595814

In [15]: %timeit f(1)
875 ns ± 1.93 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```