### PR TITLE
maint: bump dev dependencies

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,5 +1,5 @@
 pip==23.0.1
 nox==2022.11.21
 nox-poetry==1.0.2
-poetry==1.3.2
-virtualenv==20.19.0
+poetry==1.4.0
+virtualenv==20.20.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -3611,4 +3611,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "a8a20487e4462a38c023b6c933ad85ca070f6e0ebba116c739b2ea9c5dffd2d6"
+content-hash = "2cb5a6f0063103a0e160b66ce0636b07b1ba433167829cdbee76b95d49b78314"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ python = "^3.8.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"
-coverage = {extras = ["toml"], version = "^7.2.0"}
+coverage = {extras = ["toml"], version = "^7.2.1"}
 safety = "^2.3.5"
 mypy = "^1.0.1"
 typeguard = "^2.13.3"
 xdoctest = {extras = ["colors"], version = "^1.1.1"}
 sphinx = "^6.1.3"
 sphinx-autobuild = "^2021.3.14"
-pre-commit = "^3.1.0"
+pre-commit = "^3.1.1"
 flake8 = "^6.0.0"
 black = "22.12.0"
 flake8-bandit = "^4.1.1"
@@ -56,7 +56,7 @@ pytest-benchmark = "^4.0.0"
 
 
 [tool.poetry.group.utils.dependencies]
-ipython = "^8.10.0"
+ipython = "^8.11.0"
 jupyter = "^1.0.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
This is just bumping the versions of the dev dependencies.

The script `./bumpcheck.py` shows which need to be updated but does not automatically change them (it can change the ones in the requirements.txt but `poetry up` is used to change the others).

The dependabot PRs will close after this is merged.