### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,14 +59,14 @@ jobs:
 
       - name: Publish package on PyPI
         if: steps.check-version.outputs.tag
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.7.1
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1.7.1
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
               fout.write("result={}\n".format(result))
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3.2.6
+        uses: actions/cache@v3.3.0
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.0](https://github.com/actions/cache/releases/tag/v3.3.0)** on 2023-03-09T12:31:42Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.7.1](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.7.1)** on 2023-03-11T02:17:28Z
