### PR TITLE
Add Sym as a superclass for Expr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ fail_under = 100
 exclude_lines = [
     "pragma: no cover",
     "if _TYPE_CHECKING:",
+    "@overload",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ module = [
     'llvmlite.binding',
     'py',
     'symengine',
+    'numpy',
 ]
 ignore_missing_imports = true
 

--- a/src/protosym/core/evaluate.py
+++ b/src/protosym/core/evaluate.py
@@ -26,14 +26,14 @@ _S = TypeVar("_S")
 
 
 if _TYPE_CHECKING:
-    from typing import Optional, Iterable, Any
+    from typing import Optional, Sequence, Any
 
     Op1 = Callable[[_T], _T]
     Op2 = Callable[[_T, _T], _T]
-    OpN = Callable[[Iterable[_T]], _T]
+    OpN = Callable[[Sequence[_T]], _T]
 
 
-def _generic_operation_error(head: TreeExpr, argvals: Iterable[_T]) -> _T:
+def _generic_operation_error(head: TreeExpr, argvals: Sequence[_T]) -> _T:
     """Error fallback rule for handling unknown heads."""
     msg = "No rule for head: " + repr(head)
     raise NoEvaluationRuleError(msg)
@@ -91,7 +91,7 @@ class Evaluator(Generic[_T]):
 
     atoms: dict[AtomType[_AnyValue], Callable[[_AnyValue], _T]]
     operations: dict[TreeExpr, tuple[Callable[..., _T], bool]]
-    generic_operation_func: Callable[[TreeExpr, Iterable[_T]], _T]
+    generic_operation_func: Callable[[TreeExpr, Sequence[_T]], _T]
     generic_atom_func: Callable[[TreeAtom[_S]], _T]
 
     def __init__(self) -> None:
@@ -123,7 +123,7 @@ class Evaluator(Generic[_T]):
         """Add an evaluation rule for a particular head."""
         self.operations[head] = (func, False)
 
-    def add_op_generic(self, func: Callable[[TreeExpr, Iterable[_T]], _T]) -> None:
+    def add_op_generic(self, func: Callable[[TreeExpr, Sequence[_T]], _T]) -> None:
         """Add a generic fallback rule for heads."""
         self.generic_operation_func = func
 
@@ -135,7 +135,7 @@ class Evaluator(Generic[_T]):
             return self.generic_atom_func(atom)
         return atom_func(atom_value.value)
 
-    def eval_operation(self, head: TreeExpr, argvals: Iterable[_T]) -> _T:
+    def eval_operation(self, head: TreeExpr, argvals: Sequence[_T]) -> _T:
         """Evaluate one function with some values."""
         func_star = self.operations.get(head)
 

--- a/src/protosym/core/exceptions.py
+++ b/src/protosym/core/exceptions.py
@@ -11,3 +11,9 @@ class NoEvaluationRuleError(ProtoSymError):
     """Raised when an :class:`Evaluator` has no rule for an expression."""
 
     pass
+
+
+class BadRuleError(ProtoSymError):
+    """Raised when an :class:`Evaluator` is given an invalid rule."""
+
+    pass

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -248,6 +248,10 @@ class SymEvaluator(Generic[T_sym, T_val]):
         """Add a rule for an atom type."""
         self.evaluator.add_atom(atom_type.atom_type, func)
 
+    def add_atom_generic(self, func: Callable[[Any], T_val]) -> None:
+        """Add a generic fallback rule for atoms."""
+        self.evaluator.add_atom_generic(func)
+
     def add_op1(self, head: T_sym, func: Callable[[T_val], T_val]) -> None:
         """Add a rule for an unary head."""
         self.evaluator.add_op1(head.rep, func)
@@ -259,6 +263,12 @@ class SymEvaluator(Generic[T_sym, T_val]):
     def add_opn(self, head: T_sym, func: Callable[[Sequence[T_val]], T_val]) -> None:
         """Add a rule for an nary head."""
         self.evaluator.add_opn(head.rep, func)
+
+    def add_op_generic(
+        self, func: Callable[[TreeExpr, Sequence[T_val]], T_val]
+    ) -> None:
+        """Add a generic fallback rule for heads."""
+        self.evaluator.add_op_generic(func)
 
     def __call__(
         self, expr: T_sym, values: Optional[dict[T_sym, T_val]] = None

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -1,0 +1,270 @@
+"""The :class:`Sym` class.
+
+This module defines the :class:`Sym` class which should be used as the
+superclass for all user-facing symbolic classes. The :class:`Sym` class only
+has a handful of attributes and methods that are used to make it compatible
+with the rest of the machinery defined in `protosym.core`.
+"""
+from __future__ import annotations
+
+from typing import Any
+from typing import Callable
+from typing import Generic
+from typing import Optional
+from typing import Sequence
+from typing import Type
+from typing import TypeVar
+from weakref import WeakValueDictionary as _WeakDict
+
+from protosym.core.atom import AtomType
+from protosym.core.evaluate import Evaluator
+from protosym.core.tree import TreeAtom
+from protosym.core.tree import TreeExpr
+
+__all__ = ["Sym", "SymAtomType", "SymEvaluator"]
+
+T_sym = TypeVar("T_sym", bound="Sym")
+T_val = TypeVar("T_val")
+S_val = TypeVar("S_val")
+
+
+class Sym:
+    """Base class for user-facing symbolic classes.
+
+    This class should not be used directly but rather subclassed to make a
+    user-facing symbolic expression type:
+
+    >>> from protosym.core.sym import Sym
+
+    The :class:`Sym` class should be subclassed to add any desired methods such
+    as `__add__`. The :class:`Sym` class defines object construction to ensure
+    that all instances of :class:`Sym` for any given subclass and underlying
+    :class:`TreeExpr` are unique. Each :class:`Sym` instance holds an internal
+    `rep` attribute which to which all methods are delegated.
+
+    >>> class Expr(Sym):
+    ...     def __call__(self: Expr, *args: Expr) -> Expr:
+    ...         args_rep = [arg.rep for arg in args]
+    ...         return Expr(self.rep(*args_rep))
+    ...     def __add__(self: Expr, other: Expr) -> Expr:
+    ...         if not isinstance(other, Expr):
+    ...             return NotImplemented
+    ...         return Add(self, other)
+    ...
+
+    Now we can define some atom types and instances. These are wrappers around
+    :class:`AtomType` and :class:`TreeAtom`:
+
+    >>> Integer = Expr.new_atom('Integer', int)
+    >>> Integer
+    Integer
+    >>> one = Integer(1)
+    >>> one
+    Sym(TreeAtom(Integer(1)))
+    >>> print(one)
+    1
+
+    We can also define heads and operations to make compound expressions:
+
+    >>> Function = Expr.new_atom('Function', str)
+    >>> Add = Function('Add')
+    >>> print(Add)
+    Add
+    >>> expr = Add(one, one)
+    >>> print(expr)
+    Add(1, 1)
+
+    The `repr` shows the raw representation of these objects:
+
+    >>> Add
+    Sym(TreeAtom(Function('Add')))
+    >>> expr
+    Sym(TreeNode(TreeAtom(Function('Add')), TreeAtom(Integer(1)), TreeAtom(Integer(1))))
+
+    Subclasses should probably implement prettier printing.
+
+    See Also
+    ========
+
+    protosym.simplecas::Expr - A subclass of :class:`Sym`.
+    """
+
+    _all_expressions: _WeakDict[Any, Any] = _WeakDict()
+
+    rep: TreeExpr
+
+    def __new__(cls, tree_expr: TreeExpr) -> Sym:
+        """Create a new Sym wrapping `tree_expr`.
+
+        If an equivalent Sym instance already exists then the same object will
+        be returned.
+        """
+        if not isinstance(tree_expr, TreeExpr):
+            raise TypeError("First argument to Sym should be TreeExpr")
+
+        key = (cls, tree_expr)
+
+        expr = cls._all_expressions.get(key, None)
+        if expr is not None:
+            return expr  # type:ignore
+
+        obj = super().__new__(cls)
+        obj.rep = tree_expr
+
+        obj = cls._all_expressions.setdefault(key, obj)
+
+        return obj
+
+    def __repr__(self) -> str:
+        """Raw text representation of a Sym.
+
+        >>> from protosym.core.sym import Sym
+        >>> Integer = Sym.new_atom('Integer', int)
+        >>> Integer(1)
+        Sym(TreeAtom(Integer(1)))
+        """
+        return f"Sym({self.rep!r})"
+
+    def __str__(self) -> str:
+        """Prettier text representation of a Sym.
+
+        >>> from protosym.core.sym import Sym
+        >>> Integer = Sym.new_atom('Integer', int)
+        >>> print(Integer(1))
+        1
+        """
+        return str(self.rep)
+
+    @classmethod
+    def new_atom(
+        cls: Type[T_sym], name: str, typ: Type[T_val]
+    ) -> SymAtomType[T_sym, T_val]:
+        """Create a new atom type for a given :class:`Sym` subclass.
+
+        >>> from protosym.core.sym import Sym
+        >>> Integer = Sym.new_atom('Integer', int)
+        >>> one = Integer(1)
+        >>> one
+        Sym(TreeAtom(Integer(1)))
+        """
+        return SymAtomType(name, cls, typ)
+
+    @classmethod
+    def new_evaluator(
+        cls: Type[T_sym], name: str, typ: Type[T_val]
+    ) -> SymEvaluator[T_sym, T_val]:
+        """Create a :class:`SymEvaluator` for a :class:`Sym` subclass.
+
+        >>> from protosym.core.sym import Sym
+        >>> Integer = Sym.new_atom('Integer', int)
+        >>> one = Integer(1)
+        >>> eval_f64 = Sym.new_evaluator('eval_f64', float)
+        >>> eval_f64
+        eval_f64
+        >>> eval_f64.add_atom(Integer, float)
+        >>> eval_f64(one)
+        1.0
+
+        See Also
+        ========
+
+        SymEvaluator
+        """
+        return SymEvaluator(name)
+
+
+class SymAtomType(Generic[T_sym, T_val]):
+    """Wrapper around AtomType to construct atoms as Sym."""
+
+    name: str
+    sym: Callable[[TreeAtom[T_val]], T_sym]
+    atom_type: AtomType[T_val]
+
+    def __init__(
+        self, name: str, sym: Callable[[TreeAtom[T_val]], T_sym], typ: Type[T_val]
+    ) -> None:
+        """New SymAtomType."""
+        self.name = name
+        self.sym = sym
+        self.atom_type = AtomType(name, typ)
+
+    def __repr__(self) -> str:
+        """The name of the SymAtomType."""
+        return self.name
+
+    def __call__(self, value: T_val) -> T_sym:
+        """Create a new Atom as a Sym."""
+        atom = self.atom_type(value)
+        return self.sym(TreeAtom[T_val](atom))
+
+
+class SymEvaluator(Generic[T_sym, T_val]):
+    """Evaluator for a given :class:`Sym` subclass.
+
+    These should not be created directly but rather using the
+    :meth:`Sym.new_evaluator` method. First create some atom types:
+
+    >>> import math
+    >>> from protosym.core.sym import Sym
+    >>> Integer = Sym.new_atom('Integer', int)
+    >>> Function = Sym.new_atom('Function', int)
+    >>> cos = Function('cos')
+
+    Now we can make an :class:`Evaluator` and add rules to it:
+
+    >>> eval_f64 = Sym.new_evaluator('eval_f64', float)
+    >>> eval_f64
+    eval_f64
+    >>> eval_f64.add_atom(Integer, float)
+    >>> eval_f64.add_op1(cos, math.cos)
+
+    Now make an expression and evaluate the expression:
+
+    >>> one = Integer(1)
+    >>> cos_one = Sym(cos.rep(one.rep))
+    >>> print(cos_one)
+    cos(1)
+    >>> eval_f64(cos_one) # doctest: +ELLIPSIS
+    0.5403023058681...
+
+    See Also
+    ========
+
+    protosym.core.evaluate::Evaluator
+    """
+
+    def __init__(self, name: str):
+        """Create a new SymEvaluator."""
+        self.name = name
+        self.evaluator = Evaluator[T_val]()
+
+    def __repr__(self) -> str:
+        """Print as the name of the Evaluator."""
+        return self.name
+
+    def add_atom(
+        self, atom_type: SymAtomType[T_sym, S_val], func: Callable[[S_val], T_val]
+    ) -> None:
+        """Add a rule for an atom type."""
+        self.evaluator.add_atom(atom_type.atom_type, func)
+
+    def add_op1(self, head: T_sym, func: Callable[[T_val], T_val]) -> None:
+        """Add a rule for an unary head."""
+        self.evaluator.add_op1(head.rep, func)
+
+    def add_op2(self, head: T_sym, func: Callable[[T_val, T_val], T_val]) -> None:
+        """Add a rule for a binary head."""
+        self.evaluator.add_op2(head.rep, func)
+
+    def add_opn(self, head: T_sym, func: Callable[[Sequence[T_val]], T_val]) -> None:
+        """Add a rule for an nary head."""
+        self.evaluator.add_opn(head.rep, func)
+
+    def __call__(
+        self, expr: T_sym, values: Optional[dict[T_sym, T_val]] = None
+    ) -> T_val:
+        """Evaluate a given expression using the rules."""
+        values_rep = {}
+        if values is not None:
+            values_rep = {e.rep: v for e, v in values.items()}
+        return self.evaluator(expr.rep, values_rep)

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -11,6 +11,7 @@ from typing import Any
 from typing import Callable
 from typing import Generic
 from typing import Optional
+from typing import overload
 from typing import Sequence
 from typing import Type
 from typing import TypeVar
@@ -26,6 +27,47 @@ __all__ = ["Sym", "SymAtomType", "SymEvaluator"]
 T_sym = TypeVar("T_sym", bound="Sym")
 T_val = TypeVar("T_val")
 S_val = TypeVar("S_val")
+T_op = TypeVar("T_op")
+
+
+Wild = AtomType("Wild", str)
+
+
+class SymAtomType(Generic[T_sym, T_val]):
+    """Wrapper around AtomType to construct atoms as Sym."""
+
+    name: str
+    sym: Callable[[TreeAtom[T_val]], T_sym]
+    atom_type: AtomType[T_val]
+
+    def __init__(
+        self, name: str, sym: Callable[[TreeAtom[T_val]], T_sym], typ: Type[T_val]
+    ) -> None:
+        """New SymAtomType."""
+        self.name = name
+        self.sym = sym
+        self.atom_type = AtomType(name, typ)
+
+    def __repr__(self) -> str:
+        """The name of the SymAtomType."""
+        return self.name
+
+    def __call__(self, value: T_val) -> T_sym:
+        """Create a new Atom as a Sym."""
+        atom = self.atom_type(value)
+        return self.sym(TreeAtom[T_val](atom))
+
+    def __getitem__(self, wild: T_sym) -> SymAtomValue[T_sym, T_val]:
+        """Represent extracting the value from self."""
+        return SymAtomValue(self, wild)
+
+
+class SymAtomValue(Generic[T_sym, T_val]):
+    """Representation of extracting a value from an Atom."""
+
+    def __init__(self, atom_type: SymAtomType[T_sym, T_val], wild: T_sym) -> None:
+        self.atom_type = atom_type
+        self.args = (wild,)
 
 
 class Sym:
@@ -115,6 +157,17 @@ class Sym:
 
         return obj
 
+    @property
+    def head(self: T_sym) -> T_sym:
+        """Head of the expression as a Sym."""
+        return type(self)(self.rep.children[0])
+
+    @property
+    def args(self: T_sym) -> tuple[T_sym, ...]:
+        """Args of the expression as a tuple of Sym."""
+        cls = type(self)
+        return tuple(cls(child) for child in self.rep.children[1:])
+
     def __repr__(self) -> str:
         """Raw text representation of a Sym.
 
@@ -150,18 +203,33 @@ class Sym:
         return SymAtomType(name, cls, typ)
 
     @classmethod
+    def new_wild(cls: Type[T_sym], name: str) -> T_sym:
+        """Create a new wild for a given :class:`Sym` subclass.
+
+        >>> from protosym.core.sym import Sym
+        >>> a = Sym.new_wild('a')
+        >>> print(a)
+        a
+        >>> a
+        Sym(TreeAtom(Wild('a')))
+        """
+        return cls(TreeAtom(Wild(name)))
+
+    @classmethod
     def new_evaluator(
         cls: Type[T_sym], name: str, typ: Type[T_val]
     ) -> SymEvaluator[T_sym, T_val]:
         """Create a :class:`SymEvaluator` for a :class:`Sym` subclass.
 
-        >>> from protosym.core.sym import Sym
+        >>> from protosym.core.sym import Sym, PyFunc1
+        >>> a = Sym.new_wild('a')
         >>> Integer = Sym.new_atom('Integer', int)
         >>> one = Integer(1)
+        >>> int_to_float = PyFunc1(float)
         >>> eval_f64 = Sym.new_evaluator('eval_f64', float)
         >>> eval_f64
         eval_f64
-        >>> eval_f64.add_atom(Integer, float)
+        >>> eval_f64[Integer[a]] = int_to_float(a)
         >>> eval_f64(one)
         1.0
 
@@ -173,55 +241,241 @@ class Sym:
         return SymEvaluator(name)
 
 
-class SymAtomType(Generic[T_sym, T_val]):
-    """Wrapper around AtomType to construct atoms as Sym."""
+class PyFunc:
+    """Base class for wrapping callable Python functions.
 
-    name: str
-    sym: Callable[[TreeAtom[T_val]], T_sym]
-    atom_type: AtomType[T_val]
+    This should not be used directly but rather its subclasses that have
+    specific signatures should be used. The purpose of these different classes
+    is really just so that a type checker can understand what type of function
+    is expected by an :class:`Evaluator` and can check the types when a rule is
+    added. Putting together an :class:`Evaluator` at runtime inherently
+    involves dynamic typing so the checker needs a bit of help to understand
+    what is happening.
 
-    def __init__(
-        self, name: str, sym: Callable[[TreeAtom[T_val]], T_sym], typ: Type[T_val]
-    ) -> None:
-        """New SymAtomType."""
-        self.name = name
-        self.sym = sym
-        self.atom_type = AtomType(name, typ)
+    See Also
+    ========
 
-    def __repr__(self) -> str:
-        """The name of the SymAtomType."""
-        return self.name
+    PyOp1
+    PyOp2
+    PyOpN
+    HeadOp
+    AtomFunc
+    PyFunc1
+    """
 
-    def __call__(self, value: T_val) -> T_sym:
-        """Create a new Atom as a Sym."""
-        atom = self.atom_type(value)
-        return self.sym(TreeAtom[T_val](atom))
+    __slots__ = ()
+
+
+class WildCall(Generic[T_sym, T_op]):
+
+    __slots__ = ("op", "args")
+
+    def __init__(self, op: T_op, *args: T_sym):
+        self.op = op
+        self.args = args
+
+
+class PyOp(Generic[T_val], PyFunc):
+    """Base class for PyFuncs T -> T, (T, T) -> T etc.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ()
+
+
+class PyOp1(PyOp[T_val]):
+    """Wrapper for an unary func T_val -> T_val.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ("func",)
+
+    def __init__(self, func: Callable[[T_val], T_val]):
+        self.func = func
+
+    def __call__(self: T_op, arg1: T_sym) -> WildCall[T_sym, T_op]:
+        return WildCall(self, arg1)
+
+
+class PyOp2(PyOp[T_val]):
+    """Wrapper for an binary func (T_val, T_val) -> T_val.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ("func",)
+
+    def __init__(self, func: Callable[[T_val, T_val], T_val]):
+        self.func = func
+
+    def __call__(self: T_op, arg1: T_sym, arg2: T_sym) -> WildCall[T_sym, T_op]:
+        return WildCall(self, arg1, arg2)
+
+
+class PyOpN(PyOp[T_val]):
+    """Wrapper for a sequence func [T_val, ...] -> T_val.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ("func",)
+
+    def __init__(self, func: Callable[[Sequence[T_val]], T_val]):
+        self.func = func
+
+    def __call__(self: T_op, args: T_sym) -> WildCall[T_sym, T_op]:
+        return WildCall(self, args)
+
+
+class PyFunc1(Generic[S_val, T_val], PyFunc):
+    """Wrapper for unary func S_val -> T_val.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ("func",)
+
+    def __init__(self, func: Callable[[S_val], T_val]):
+        self.func = func
+
+    def __call__(self: T_op, arg: T_sym) -> WildCall[T_sym, T_op]:
+        return WildCall(self, arg)
+
+
+class AtomFunc(Generic[T_val], PyFunc):
+    """Wrapper for unary func object -> T_val.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ("func",)
+
+    def __init__(self, func: Callable[[object], T_val]):
+        self.func = func
+
+    def __call__(self: T_op, arg: T_sym) -> WildCall[T_sym, T_op]:
+        return WildCall(self, arg)
+
+
+class HeadOp(Generic[T_val], PyFunc):
+    """Wrapper for generic head function.
+
+    See Also
+    ========
+
+    PyFunc
+    """
+
+    __slots__ = ("func",)
+
+    # XXX: Ideally this function would not operate on TreeExpr because it means
+    # that the function wrapped by HeadOp needs to know how about TreeExpr
+    # which mixes up the levels we want to work with. Not sure yet what is the
+    # best way to handle this. Currently where HeadOp is used the TreeExpr
+    # argument is either ignored or just converted to a string.
+
+    def __init__(self, func: Callable[[TreeExpr, Sequence[T_val]], T_val]):
+        self.func = func
+
+    def __call__(self: T_op, head: T_sym, args: T_sym) -> WildCall[T_sym, T_op]:
+        return WildCall(self, head, args)
+
+
+class _AtomRuleType:
+    """Internal type for the AtomRule marker."""
+
+    __slots__ = ()
+
+    def __getitem__(self, wild: T_sym) -> AtomRuleType[T_sym]:
+        return AtomRuleType(wild)
+
+
+class AtomRuleType(Generic[T_sym]):
+    """Generic atom rule representation."""
+
+    __slots__ = ("args",)
+
+    def __init__(self, wild: T_sym):
+        self.args = (wild,)
+
+
+class _HeadRuleType:
+    """Internal type for the HeadRule marker."""
+
+    __slots__ = ()
+
+    def __call__(self, head: T_sym, args: T_sym) -> HeadRuleType[T_sym]:
+        return HeadRuleType(head, args)
+
+
+class HeadRuleType(Generic[T_sym]):
+    """Generic atom rule representation."""
+
+    __slots__ = ("args",)
+
+    def __init__(self, head: T_sym, args: T_sym):
+        self.args = (head, args)
+
+
+AtomRule = _AtomRuleType()
+HeadRule = _HeadRuleType()
 
 
 class SymEvaluator(Generic[T_sym, T_val]):
     """Evaluator for a given :class:`Sym` subclass.
 
     These should not be created directly but rather using the
-    :meth:`Sym.new_evaluator` method. First create some atom types:
+    :meth:`Sym.new_evaluator` method. The demonstration here is somewhat
+    awkward because :class:`Sym` does not define `__call__` although it is
+    expected that most subclasses would.
+
+    First create some atom types:
 
     >>> import math
-    >>> from protosym.core.sym import Sym
+    >>> from protosym.core.sym import Sym, PyOp1, PyFunc1
     >>> Integer = Sym.new_atom('Integer', int)
     >>> Function = Sym.new_atom('Function', int)
-    >>> cos = Function('cos')
+    >>> cos = Function('cos').rep
+    >>> a = Sym.new_wild('a')
+    >>> ar = a.rep
+    >>> one = Integer(1).rep
+
+    Make some symbolically typed functions for evaluation:
+
+    >>> f64_from_int = PyFunc1(float)
+    >>> f64_cos = PyOp1(math.cos)
 
     Now we can make an :class:`Evaluator` and add rules to it:
 
     >>> eval_f64 = Sym.new_evaluator('eval_f64', float)
     >>> eval_f64
     eval_f64
-    >>> eval_f64.add_atom(Integer, float)
-    >>> eval_f64.add_op1(cos, math.cos)
+    >>> eval_f64[Integer[a]] = f64_from_int(a)
+    >>> eval_f64[Sym(cos(ar))] = f64_cos(a)
 
     Now make an expression and evaluate the expression:
 
-    >>> one = Integer(1)
-    >>> cos_one = Sym(cos.rep(one.rep))
+    >>> cos_one = Sym(cos(one))
     >>> print(cos_one)
     cos(1)
     >>> eval_f64(cos_one) # doctest: +ELLIPSIS
@@ -231,6 +485,7 @@ class SymEvaluator(Generic[T_sym, T_val]):
     ========
 
     protosym.core.evaluate::Evaluator
+    protosym.simplecas::Expr.new_evaluator
     """
 
     def __init__(self, name: str):
@@ -238,37 +493,102 @@ class SymEvaluator(Generic[T_sym, T_val]):
         self.name = name
         self.evaluator = Evaluator[T_val]()
 
+    # e.g. eval_f64[cos(a)] = f64_cos(a)
+    @overload
+    def __setitem__(  # noqa: D105
+        self,
+        pattern: T_sym,
+        call: WildCall[T_sym, PyOp1[T_val]]
+        | WildCall[T_sym, PyOp2[T_val]]
+        | WildCall[T_sym, PyOpN[T_val]],
+    ) -> None:
+        ...
+
+    # e.g. eval_f64[Integer[a]] = f64_from_int
+    @overload
+    def __setitem__(  # noqa: D105
+        self,
+        pattern: SymAtomValue[T_sym, S_val],
+        call: WildCall[T_sym, PyFunc1[S_val, T_val]],
+    ) -> None:
+        ...
+
+    # e.g. eval_repr[AtomRule[a]] = AtomFunc(repr)
+    @overload
+    def __setitem__(  # noqa: D105
+        self,
+        pattern: AtomRuleType[T_sym],
+        call: WildCall[T_sym, AtomFunc[T_val]],
+    ) -> None:
+        ...
+
+    # e.g. eval_repr[HeadRule(a, b)] = HeadOp(...)
+    @overload
+    def __setitem__(  # noqa: D105
+        self,
+        pattern: HeadRuleType[T_sym],
+        call: WildCall[T_sym, HeadOp[T_val]],
+    ) -> None:
+        ...
+
+    def __setitem__(
+        self,
+        pattern: T_sym
+        | SymAtomValue[T_sym, S_val]
+        | AtomRuleType[T_sym]
+        | HeadRuleType[T_sym],
+        call: WildCall[T_sym, PyOp1[T_val]]
+        | WildCall[T_sym, PyOp2[T_val]]
+        | WildCall[T_sym, PyOpN[T_val]]
+        | WildCall[T_sym, PyFunc1[S_val, T_val]]
+        | WildCall[T_sym, AtomFunc[T_val]]
+        | WildCall[T_sym, HeadOp[T_val]],
+    ) -> None:
+        """Add an evaluation rule."""
+        if not isinstance(call, WildCall):
+            raise TypeError("Rule function should be a symbolic call.")
+
+        if pattern.args != call.args:
+            raise TypeError("Pattern and rule signatures do not match.")
+
+        if isinstance(pattern, AtomRuleType):
+            if not isinstance(call.op, AtomFunc):
+                raise TypeError("AtomRule func should be of type AtomFunc")
+            self.evaluator.add_atom_generic(call.op.func)
+
+        elif isinstance(pattern, HeadRuleType):
+            if not isinstance(call.op, HeadOp):
+                raise TypeError("HeadRule func should be of type HeadOp")
+            self.evaluator.add_op_generic(call.op.func)
+
+        elif isinstance(pattern, SymAtomValue):
+            if not isinstance(call.op, PyFunc1):
+                raise TypeError("Rule for an Atom should be pf type PyFunc1")
+            self.evaluator.add_atom(pattern.atom_type.atom_type, call.op.func)
+
+        else:
+            if not isinstance(call.op, PyOp):
+                raise TypeError("Rule for a head should by of type PyOp")
+            self.add_op(pattern.head, call.op)
+
+    def add_op(
+        self,
+        head: T_sym,
+        op: PyOp1[T_val] | PyOp2[T_val] | PyOpN[T_val],
+    ) -> None:
+        """Add an evaluation rule like sin(a) -> evalf_64(a)."""
+        if isinstance(op, PyOp1):
+            self.evaluator.add_op1(head.rep, op.func)
+        elif isinstance(op, PyOp2):
+            self.evaluator.add_op2(head.rep, op.func)
+        elif isinstance(op, PyOpN):
+            self.evaluator.add_opn(head.rep, op.func)
+        else:
+            raise TypeError("Not a PyFunc")
+
     def __repr__(self) -> str:
         """Print as the name of the Evaluator."""
         return self.name
-
-    def add_atom(
-        self, atom_type: SymAtomType[T_sym, S_val], func: Callable[[S_val], T_val]
-    ) -> None:
-        """Add a rule for an atom type."""
-        self.evaluator.add_atom(atom_type.atom_type, func)
-
-    def add_atom_generic(self, func: Callable[[Any], T_val]) -> None:
-        """Add a generic fallback rule for atoms."""
-        self.evaluator.add_atom_generic(func)
-
-    def add_op1(self, head: T_sym, func: Callable[[T_val], T_val]) -> None:
-        """Add a rule for an unary head."""
-        self.evaluator.add_op1(head.rep, func)
-
-    def add_op2(self, head: T_sym, func: Callable[[T_val, T_val], T_val]) -> None:
-        """Add a rule for a binary head."""
-        self.evaluator.add_op2(head.rep, func)
-
-    def add_opn(self, head: T_sym, func: Callable[[Sequence[T_val]], T_val]) -> None:
-        """Add a rule for an nary head."""
-        self.evaluator.add_opn(head.rep, func)
-
-    def add_op_generic(
-        self, func: Callable[[TreeExpr, Sequence[T_val]], T_val]
-    ) -> None:
-        """Add a generic fallback rule for heads."""
-        self.evaluator.add_op_generic(func)
 
     def __call__(
         self, expr: T_sym, values: Optional[dict[T_sym, T_val]] = None

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -562,7 +562,7 @@ class SymEvaluator(Generic[T_sym, T_val]):
         if isinstance(call.op, PyOpN):
             (callarg,) = call.args
             if pattern.args != (star(callarg),):
-                raise BadRuleError("Nary function needs a star-rule.")
+                raise BadRuleError("varargs function needs a star-rule.")
         elif pattern.args != call.args:
             raise BadRuleError("Pattern and rule signatures do not match.")
 

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -85,7 +85,7 @@ class Sym:
     as `__add__`. The :class:`Sym` class defines object construction to ensure
     that all instances of :class:`Sym` for any given subclass and underlying
     :class:`TreeExpr` are unique. Each :class:`Sym` instance holds an internal
-    `rep` attribute which to which all methods are delegated.
+    `rep` attribute to which all methods are delegated.
 
     >>> class Expr(Sym):
     ...     def __call__(self: Expr, *args: Expr) -> Expr:

--- a/src/protosym/simplecas.py
+++ b/src/protosym/simplecas.py
@@ -21,6 +21,7 @@ from protosym.core.sym import PyFunc1
 from protosym.core.sym import PyOp1
 from protosym.core.sym import PyOp2
 from protosym.core.sym import PyOpN
+from protosym.core.sym import star
 from protosym.core.sym import Sym
 from protosym.core.tree import forward_graph
 from protosym.core.tree import topological_sort
@@ -500,8 +501,8 @@ def _get_eval_to_sympy() -> SymEvaluator[Expr, Any]:
     eval_to_sympy[Integer[a]] = PyFunc1(sympy.Integer)(a)
     eval_to_sympy[Symbol[a]] = PyFunc1(sympy.Symbol)(a)
     eval_to_sympy[Function[a]] = PyFunc1(sympy.Function)(a)
-    eval_to_sympy[Add(a)] = PyOpN[Any](lambda a: sympy.Add(*a))(a)
-    eval_to_sympy[Mul(a)] = PyOpN[Any](lambda a: sympy.Mul(*a))(a)
+    eval_to_sympy[Add(star(a))] = PyOpN[Any](lambda a: sympy.Add(*a))(a)
+    eval_to_sympy[Mul(star(a))] = PyOpN[Any](lambda a: sympy.Mul(*a))(a)
     eval_to_sympy[a**b] = PyOp2(sympy.Pow)(a, b)
     eval_to_sympy[sin(a)] = PyOp1(sympy.sin)(a)
     eval_to_sympy[cos(a)] = PyOp1(sympy.cos)(a)
@@ -579,8 +580,8 @@ f64_cos = PyOp1[float](math.cos)
 
 eval_f64 = Expr.new_evaluator("eval_f64", float)
 eval_f64[Integer[a]] = f64_from_int(a)
-eval_f64[Add(a)] = f64_add(a)
-eval_f64[Mul(a)] = f64_mul(a)
+eval_f64[Add(star(a))] = f64_add(a)
+eval_f64[Mul(star(a))] = f64_mul(a)
 eval_f64[a**b] = f64_pow(a, b)
 eval_f64[sin(a)] = f64_sin(a)
 eval_f64[cos(a)] = f64_cos(a)
@@ -606,8 +607,8 @@ eval_repr[AtomRule[a]] = repr_atom(a)
 eval_repr[Integer[a]] = str_from_int(a)
 eval_repr[Symbol[a]] = str_from_str(a)
 eval_repr[Function[a]] = str_from_str(a)
-eval_repr[Add(a)] = repr_add(a)
-eval_repr[Mul(a)] = repr_mul(a)
+eval_repr[Add(star(a))] = repr_add(a)
+eval_repr[Mul(star(a))] = repr_mul(a)
 eval_repr[a**b] = repr_pow(a, b)
 
 # ------------------------------------------------------------------------- #
@@ -627,8 +628,8 @@ eval_latex[HeadRule(a, b)] = repr_call(a, b)
 eval_latex[Integer[a]] = str_from_int(a)
 eval_latex[Symbol[a]] = str_from_str(a)
 eval_latex[Function[a]] = str_from_str(a)
-eval_latex[Add(a)] = latex_add(a)
-eval_latex[Mul(a)] = latex_mul(a)
+eval_latex[Add(star(a))] = latex_add(a)
+eval_latex[Mul(star(a))] = latex_mul(a)
 eval_latex[a**b] = latex_pow(a, b)
 eval_latex[sin(a)] = latex_sin(a)
 eval_latex[cos(a)] = latex_cos(a)

--- a/tests/core/test_sym.py
+++ b/tests/core/test_sym.py
@@ -26,6 +26,7 @@ def test_Sym() -> None:
     Symbol = Expr.new_atom("Symbol", str)
     Function = Expr.new_atom("Function", str)
     cos = Function("cos")
+    sin = Function("sin")
     Add = Function("Add")
     one = Integer(1)
     x = Symbol("x")
@@ -43,11 +44,17 @@ def test_Sym() -> None:
 
     to_str = Expr.new_evaluator("to_str", str)
     to_str.add_atom(Integer, str)
+    to_str.add_atom_generic(str)
     to_str.add_op1(cos, lambda s: f"cos({s})")
     to_str.add_opn(Add, " + ".join)
+    to_str.add_op_generic(lambda f, a: f"{f}({', '.join(a)})")
 
     assert to_str(cos(one)) == "cos(1)"
     assert to_str(Add(one, one, one)) == "1 + 1 + 1"
+
+    # Test the generic rules
+    assert to_str(sin) == "sin"
+    assert to_str(sin(one)) == "sin(1)"
 
     assert type(to_str) == SymEvaluator
     assert repr(to_str) == repr(to_str) == "to_str"

--- a/tests/core/test_sym.py
+++ b/tests/core/test_sym.py
@@ -22,42 +22,99 @@ from protosym.core.sym import SymEvaluator
 from protosym.core.tree import TreeAtom
 
 
-def test_Sym() -> None:
-    """Test defining a simple subclass of Sym."""
+class Expr(Sym):
+    """Simple Sym subclass."""
 
-    class Expr(Sym):
-        def __repr__(self) -> str:
-            return to_str(self)
+    # Really repr should use to_str but we test that separately.
+    def __repr__(self) -> str:
+        """Pretty print with recursion."""
+        if not self.args:
+            return str(self.rep)
+        else:
+            argstr = ", ".join(map(repr, self.args))
+            return f"{self.head}({argstr})"
 
-        def __call__(self, *args: Expr) -> Expr:
-            args_rep = [arg.rep for arg in args]
-            return Expr(self.rep(*args_rep))
+    def __call__(self, *args: Expr) -> Expr:
+        """Construct a new Expr."""
+        args_rep = [arg.rep for arg in args]
+        return Expr(self.rep(*args_rep))
 
+
+def _make_atoms() -> tuple[
+    SymAtomType[Expr, int],
+    SymAtomType[Expr, str],
+    Expr,
+    Expr,
+    Expr,
+    Expr,
+    Expr,
+    Expr,
+    Expr,
+]:
+    """Set up a Sym subclass and create some atoms etc."""
     Integer = Expr.new_atom("Integer", int)
-    Symbol = Expr.new_atom("Symbol", str)
     Function = Expr.new_atom("Function", str)
+    Symbol = Expr.new_atom("Symbol", str)
     cos = Function("cos")
     sin = Function("sin")
     Add = Function("Add")
     one = Integer(1)
+    a = Expr.new_wild("a")
+    b = Expr.new_wild("b")
     x = Symbol("x")
 
-    assert str(Integer) == repr(Integer) == "Integer"
+    return Integer, Function, cos, sin, Add, one, a, b, x
+
+
+def test_Sym() -> None:
+    """Test a few properties of Sym separately."""
+    s_one = Sym.new_atom("Integer", int)(1)
+    assert str(s_one) == "1"
+    assert repr(s_one) == "Sym(TreeAtom(Integer(1)))"
+
+
+def test_Sym_str() -> None:
+    """Test str of Sym-related objects."""
+    Integer, Function, cos, sin, Add, one, a, b, x = _make_atoms()
+
+    obj_str = [
+        (Integer, "Integer"),
+        (Function, "Function"),
+        (cos, "cos"),
+        (sin, "sin"),
+        (Add, "Add"),
+        (one, "1"),
+        (cos(one), "cos(1)"),
+        (Add(one, one), "Add(1, 1)"),
+        (a, "a"),
+        (b, "b"),
+    ]
+    for obj, objstr in obj_str:
+        assert str(obj) == repr(obj) == objstr
+
+
+def test_Sym_types() -> None:
+    """Test types of Sym-related objects."""
+    Integer, Function, cos, sin, Add, one, a, b, x = _make_atoms()
 
     raises(TypeError, lambda: Expr(1))  # type:ignore
     assert Expr(one.rep) is one
-
     assert type(Integer) is SymAtomType
     assert type(Function) is SymAtomType
     assert type(cos) is Expr
     assert type(Add) is Expr
     assert type(cos.rep) is TreeAtom
-
-    a = Expr.new_wild("a")
-    b = Expr.new_wild("b")
     assert type(a) == type(b) == Expr
 
+
+def test_Sym_evaluator() -> None:
+    """Test creating a str-evaluator for Sym."""
+    Integer, Function, cos, sin, Add, one, a, b, x = _make_atoms()
+
     to_str = Expr.new_evaluator("to_str", str)
+    assert type(to_str) == SymEvaluator
+    assert repr(to_str) == repr(to_str) == "to_str"
+
     to_str[Integer[a]] = PyFunc1[int, str](str)(a)
     to_str[AtomRule[a]] = AtomFunc(str)(a)
     to_str[cos(a)] = PyOp1(lambda s: f"cos({s})")(a)
@@ -71,8 +128,12 @@ def test_Sym() -> None:
     assert to_str(sin) == "sin"
     assert to_str(sin(one)) == "sin(1)"
 
-    assert type(to_str) == SymEvaluator
-    assert repr(to_str) == repr(to_str) == "to_str"
+
+def test_Sym_evaluator_float() -> None:
+    """Test creating a str-evaluator for float."""
+    Integer, Function, cos, sin, Add, one, a, b, x = _make_atoms()
+
+    x = Expr.new_atom("Symbol", str)("x")
 
     eval_f64 = Expr.new_evaluator("eval_f64", float)
     eval_f64[Integer[a]] = PyFunc1[int, float](float)(a)
@@ -83,9 +144,12 @@ def test_Sym() -> None:
     assert eval_f64(Add(one, one)) == 2.0
     assert eval_f64(Add(x, one), {x: -1.0}) == 0.0
 
-    s_one = Sym.new_atom("Integer", int)(1)
-    assert str(s_one) == "1"
-    assert repr(s_one) == "Sym(TreeAtom(Integer(1)))"
+
+def test_Sym_evaluator_bad_rules() -> None:
+    """Test SymEvaluator bad rule handling."""
+    Integer, Function, cos, sin, Add, one, a, b, x = _make_atoms()
+
+    eval_f64 = Expr.new_evaluator("eval_f64", float)
 
     bad_examples = [
         (Integer[a], PyOp1(math.cos)(a)),

--- a/tests/core/test_sym.py
+++ b/tests/core/test_sym.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import math
+
+from pytest import approx
+from pytest import raises
+
+from protosym.core.sym import Sym
+from protosym.core.sym import SymAtomType
+from protosym.core.sym import SymEvaluator
+from protosym.core.tree import TreeAtom
+
+
+def test_Sym() -> None:
+    """Test defining a simple subclass of Sym."""
+
+    class Expr(Sym):
+        def __repr__(self) -> str:
+            return to_str(self)
+
+        def __call__(self, *args: Expr) -> Expr:
+            args_rep = [arg.rep for arg in args]
+            return Expr(self.rep(*args_rep))
+
+    Integer = Expr.new_atom("Integer", int)
+    Symbol = Expr.new_atom("Symbol", str)
+    Function = Expr.new_atom("Function", str)
+    cos = Function("cos")
+    Add = Function("Add")
+    one = Integer(1)
+    x = Symbol("x")
+
+    assert str(Integer) == repr(Integer) == "Integer"
+
+    raises(TypeError, lambda: Expr(1))  # type:ignore
+    assert Expr(one.rep) is one
+
+    assert type(Integer) is SymAtomType
+    assert type(Function) is SymAtomType
+    assert type(cos) is Expr
+    assert type(Add) is Expr
+    assert type(cos.rep) is TreeAtom
+
+    to_str = Expr.new_evaluator("to_str", str)
+    to_str.add_atom(Integer, str)
+    to_str.add_op1(cos, lambda s: f"cos({s})")
+    to_str.add_opn(Add, " + ".join)
+
+    assert to_str(cos(one)) == "cos(1)"
+    assert to_str(Add(one, one, one)) == "1 + 1 + 1"
+
+    assert type(to_str) == SymEvaluator
+    assert repr(to_str) == repr(to_str) == "to_str"
+
+    eval_f64 = Expr.new_evaluator("eval_f64", float)
+    eval_f64.add_atom(Integer, float)
+    eval_f64.add_op1(cos, math.cos)
+    eval_f64.add_op2(Add, lambda a, b: a + b)
+
+    assert eval_f64(cos(one)) == approx(0.5403023058681398)
+    assert eval_f64(Add(one, one)) == 2.0
+    assert eval_f64(Add(x, one), {x: -1.0}) == 0.0
+
+    s_one = Sym.new_atom("Integer", int)(1)
+    assert str(s_one) == "1"
+    assert repr(s_one) == "Sym(TreeAtom(Integer(1)))"

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -1,10 +1,10 @@
 from pytest import raises
 from pytest import skip
 
+from protosym.core.sym import SymAtomType
 from protosym.simplecas import Add
 from protosym.simplecas import cos
 from protosym.simplecas import Expr
-from protosym.simplecas import ExprAtomType
 from protosym.simplecas import expressify
 from protosym.simplecas import ExpressifyError
 from protosym.simplecas import f
@@ -29,7 +29,7 @@ def test_simplecas_types() -> None:
     """Basic tests for type of Expr."""
     assert type(x) == Expr
     assert type(Mul) == Expr
-    assert type(Integer) == ExprAtomType
+    assert type(Integer) == SymAtomType
     assert type(Integer(1)) == Expr
     assert type(Mul(x, Integer(1))) == Expr
     raises(TypeError, lambda: Expr([]))  # type: ignore
@@ -117,6 +117,7 @@ def test_simplecas_repr() -> None:
     assert str(x * y) == "(x*y)"
     assert str(x**two) == "x**2"
     assert str(x + x + x) == "((x + x) + x)"
+    assert repr(x + x + x) == "((x + x) + x)"
 
 
 def test_simplecas_latex() -> None:


### PR DESCRIPTION
This PR adds a class Sym in the core to be the superclass for user-facing classes like Expr. This makes it possible to define a nicer interface that can be used to specify the rules of Evaluators so instead of
```python
eval_f64.add_op(Pow, math.pow)
```
we can have something that looks more like pattern matching:
```python
eval_f64[a**b] = f64_pow(a, b)
```
Currently making this work in a type-safe way needs lots of function wrappers and is a bit complicated. I had been working on a way to represent Python code symbolically that could have been used to make that part nicer but I'm going to postpone that for now because this gets the syntax to where I want it to be for specifying evaluation rules.

The idea is to have one module somewhere that defines lots of type-specific operations like:
```python
# f64.py
f64_pow = PyOp2[float](math.pow)
f64_sum = PyOpN[float](math.fsum)
...
```
And then these functions are reusable and can be used as evaluation rules in a symbolic-looking way:
```python
eval_f64 = Expr.new_evaluator()
eval_f64[a**b] = f64_pow(a, b)
eval_f64[Add(star(a))] = f64_sum(a)
```
Then if the front-end uses things like `f64_pow` from the core a lower-level implementation in C or Rust could internally provide its own special versions of these and optimise them internally rather than using the Python level callables. Then the frontend code for simplecas can look more like a declarative DSL rather than having lots of Python callables and imperative code. This is the main goal that I'm striving for.

The need for the Sym class to be in core is so that it can define the common interface `.rep` that would be needed for implementing things in the core while making them directly usable with something like `Expr`. I intend to move the differentiation code into a generic Differentiator class in the core which is also made possible by this.

Making this work for Evaluator has been quite complex because of the interaction between the symbolic and lower-level types (the internal values of the atoms). In the case of symbolic rewrites it should be a lot easier but I would intend to have the same sort of syntax e.g.:
```python
exp2trig = Rewriter()
exp2trig[exp(a)] = cosh(a) + sinh(a)
exp2trig[exp(I*a)] = cos(a) + I*sin(a)
...
```
There it is a lot easier though because all the types are simple.