### PR TITLE
Add Matrix and lambdification of matrices

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -141,7 +141,7 @@ def mypy(session: Session) -> None:
 @session(python=python_versions)
 def tests(session: Session) -> None:
     """Run the test suite."""
-    session.install(".", "sympy", "llvmlite")
+    session.install(".", "sympy", "llvmlite", "numpy")
     session.install("coverage[toml]", "pytest", "pygments")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
@@ -179,7 +179,7 @@ def coverage(session: Session) -> None:
 def xdoctest(session: Session) -> None:
     """Run examples with xdoctest."""
     args = session.posargs or ["all"]
-    session.install(".", "sympy", "llvmlite")
+    session.install(".", "sympy", "llvmlite", "numpy")
     session.install("xdoctest[colors]")
     session.run("python", "-m", "xdoctest", "--quiet", package, *args)
 

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -270,7 +270,6 @@ class PyFunc:
 
 
 class WildCall(Generic[T_sym, T_op]):
-
     __slots__ = ("op", "args")
 
     def __init__(self, op: T_op, *args: T_sym):

--- a/src/protosym/simplecas.py
+++ b/src/protosym/simplecas.py
@@ -1052,9 +1052,9 @@ def _lambdify_llvm(args: list[TreeExpr], expression: TreeExpr) -> Callable[..., 
 
 def _to_llvm_f64_matrix(symargs: list[TreeExpr], mat: Matrix) -> str:  # noqa [C901]
     """Code for LLVM IR function computing ``expression`` from ``symargs``."""
-    # expression = bin_expand(expression)
+    elements_graph = bin_expand(mat.elements_graph.rep)
 
-    graph = forward_graph(mat.elements_graph.rep)
+    graph = forward_graph(elements_graph)
 
     argnames = {s: f'%"{s}"' for s in symargs}  # noqa
 

--- a/tests/core/test_sym.py
+++ b/tests/core/test_sym.py
@@ -40,17 +40,19 @@ class Expr(Sym):
         return Expr(self.rep(*args_rep))
 
 
-def _make_atoms() -> tuple[
-    SymAtomType[Expr, int],
-    SymAtomType[Expr, str],
-    Expr,
-    Expr,
-    Expr,
-    Expr,
-    Expr,
-    Expr,
-    Expr,
-]:
+def _make_atoms() -> (
+    tuple[
+        SymAtomType[Expr, int],
+        SymAtomType[Expr, str],
+        Expr,
+        Expr,
+        Expr,
+        Expr,
+        Expr,
+        Expr,
+        Expr,
+    ]
+):
     """Set up a Sym subclass and create some atoms etc."""
     Integer = Expr.new_atom("Integer", int)
     Function = Expr.new_atom("Function", str)

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -376,6 +376,12 @@ def test_simplecas_lambdify_llvm_mat() -> None:
     expected = np.array([[1, 2, 0], [4, 0, 6]], np.float64)
     assert np.all(f() == expected)
 
+    z = Symbol("z")
+    M = Matrix([[Add(x, y, z), Mul(x, y, z)]])
+    f = lambdify([x, y, z], M)
+    expected = np.array([[9, 24]], np.float64)
+    assert np.all(f(2, 3, 4) == expected)
+
     raises(LLVMNotImplementedError, lambda: lambdify([x], Matrix([[g(x)]])))
     raises(LLVMNotImplementedError, lambda: lambdify([], Matrix([[x]])))
 

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -285,3 +285,12 @@ def test_simplecas_lambdify_llvm() -> None:
     val1 = expr1.eval_f64({x: 1.0})
     f = lambdify([x], expr1)
     assert f(1) == f(1.0) == val1
+
+
+def test_simplecas_lambdify_llvm_mat() -> None:
+    """Test simplecas lambdify for a simple matrix."""
+    from protosym.simplecas import _lambdify_llvm_matrix
+    import numpy as np
+
+    f = _lambdify_llvm_matrix()
+    assert np.all(f() == np.array([[1, 2], [3, 4]], float))


### PR DESCRIPTION
Adds a simple Matrix class with some basic properties. I am not sure that this is is really how I want matrices to be implemented in general but this can do for now.

The Matrix class only supports matrix addition and differentiation but not matrix multiplication or anything like LUsolve (it is not hard to add those things). The key feature of the Matrix class is that it uses a single expression graph for all elements of the matrix. This means that when computing the derivative of a matrix a single forward accumulation pass is used to compute the derivative of every element of the Matrix. The Matrix class itself is designed to be sparse and to be somewhat optimised for the case of a matrix that has few nonzero entries.

Also adds lambdification of matrices using numpy and llvm to create a numpy array. The code for that part can be tidied up and better organised. Eventually I want most of the logic for things like IR generation to be handled by symbolic rewrite rules but those aren't implemented yet so for now I've just copy-pasted bts of the lambdify code to get things working quickly.