### PR TITLE
feat(simplecas): add to/from sympy matrix conversions

### DIFF
--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -191,6 +191,20 @@ def test_simplecas_to_sympy() -> None:
     raises(NotImplementedError, lambda: Expr.from_sympy(sympy.ord0))
 
 
+def test_simplecas_to_sympy_matrix() -> None:
+    """Test converting to SymPy Matrix and back."""
+    try:
+        import sympy
+    except ImportError:
+        skip("SymPy not installed")
+
+    x_sym = sympy.Symbol("x")
+    sinx_sym = sympy.sin(x_sym)
+    cosx_sym = sympy.cos(x_sym)
+    M = sympy.Matrix([[sinx_sym, cosx_sym], [-cosx_sym, sinx_sym]])
+    assert M == Matrix.from_sympy(M).to_sympy()
+
+
 def test_simplecas_eval_f64() -> None:
     """Test basic float evaluation with eval_f64."""
     assert sin(cos(x)).eval_f64({x: 1.0}) == 0.5143952585235492


### PR DESCRIPTION
Add conversions to and from sympy matrices. Also make conversion from sympy much more efficient for ordinary expressions. Demonstration:
```python
In [28]: M = randMatrix(10, percent=20)*sin(x) + randMatrix(10, percent=20)*cos(x)

In [29]: M10 = M**10

In [30]: sum(M10.applyfunc(Expr.count_ops))
Out[30]: 32422

In [31]: from protosym.simplecas import Matrix, x as xp

In [32]: %time Mp = Matrix.from_sympy(M10)
CPU times: user 82.5 ms, sys: 2.01 ms, total: 84.5 ms
Wall time: 83.4 ms

In [33]: %time Mpd = Mp.diff(xp)
CPU times: user 59.9 ms, sys: 1 ms, total: 60.9 ms
Wall time: 59.4 ms

In [34]: %time ok = Mpd.to_sympy()
CPU times: user 1.85 s, sys: 3.98 ms, total: 1.86 s
Wall time: 1.86 s

In [37]: %time res = M10.diff(x)
CPU times: user 6.94 s, sys: 3.98 ms, total: 6.95 s
Wall time: 6.97 s
```
The slowest part is converting back to sympy. I'm not sure what can be done about that. It's worth noting that converting back to sympy does tend to reduce the op count so maybe if something was done to reduce the op count before converting back to sympy that would help. The example above does not have much in the way of repeating subexpressions but bigger gains can be seen in that case.