### PR TITLE
fix(diff): fix differentiation of constant matrices

### DIFF
--- a/src/protosym/simplecas/expr.py
+++ b/src/protosym/simplecas/expr.py
@@ -585,15 +585,16 @@ def _diff_forward(expression: TreeExpr, sym: TreeExpr) -> TreeExpr:
         args = [stack[i] for i in indices]
         diff_args = [diff_stack[i] for i in indices]
         expr = func(*args)
+        diff_terms: list[TreeExpr]
 
-        if set(diff_args) == {zero.rep}:
+        if func == List.rep:
+            diff_terms = [List.rep(*diff_args)]
+        elif set(diff_args) == {zero.rep}:
             diff_terms = []
         elif func == Add.rep:
             diff_terms = [da for da in diff_args if da != zero.rep]
         elif func == Mul.rep:
             diff_terms = _prod_rule_forward(args, diff_args)
-        elif func == List.rep:
-            diff_terms = [List.rep(*diff_args)]
         else:
             diff_terms = _chain_rule_forward(func, args, diff_args)
 

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -329,6 +329,10 @@ def test_simplecas_Matrix_diff() -> None:
     """Test Matrix repr."""
     M = Matrix([[1, 2], [x, 0]])
     assert M.diff(x).tolist() == [[zero, zero], [one, zero]]
+
+    M = Matrix([[1, 2], [3, 4]])
+    assert M.diff(x).tolist() == [[zero, zero], [zero, zero]]
+
     raises(TypeError, lambda: M.diff([]))  # type:ignore
 
 


### PR DESCRIPTION
Fixes this bug:
```python
In [3]: from protosym.simplecas import Matrix, x

In [4]: Matrix([[1, 2], [3, 4]]).diff(x)
Out[4]: ---------------------------------------------------------------------------
IndexError
```
The problem is that the differentiation routine tries to return zero as the derivative for the list if the derivative of all "arguments" to the list are zero. Then we end up with this inconsistent data structure:
```python
In [5]: Matrix([[1, 2], [3, 4]]).diff(x).elements_graph
Out[5]: List()

In [6]: Matrix([[1, 2], [3, 4]]).diff(x).entrymap
Out[6]: {(0, 0): 0, (0, 1): 1, (1, 0): 2, (1, 1): 3}
```
This PR gives:
```python
In [1]: from protosym.simplecas import Matrix, x

In [2]: Matrix([[1, 2], [3, 4]]).diff(x).elements_graph
Out[2]: List(0, 0, 0, 0)

In [3]: Matrix([[1, 2], [3, 4]]).diff(x).entrymap
Out[3]: {(0, 0): 0, (0, 1): 1, (1, 0): 2, (1, 1): 3}
```
That's an improvement but really the zeros should be filtered out from the sparse matrix. In any case for now just fix the bug.