### PR TITLE
types: fix type annotations for pyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@
 /.nox/
 /.python-version
 /.pytype/
+/.local/
 /dist/
 /docs/_build/
 /src/*.egg-info/
 __pycache__/
 *.swp
 .venv
+node_modules
 my

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -40,12 +40,10 @@ class SymAtomType(Generic[T_sym, T_val]):
     """Wrapper around AtomType to construct atoms as Sym."""
 
     name: str
-    sym: Callable[[TreeAtom[T_val]], T_sym]
+    sym: Type[T_sym]
     atom_type: AtomType[T_val]
 
-    def __init__(
-        self, name: str, sym: Callable[[TreeAtom[T_val]], T_sym], typ: Type[T_val]
-    ) -> None:
+    def __init__(self, name: str, sym: Type[T_sym], typ: Type[T_val]) -> None:
         """New SymAtomType."""
         self.name = name
         self.sym = sym
@@ -167,7 +165,7 @@ class Sym:
 
     @property
     def args(self: T_sym) -> tuple[T_sym, ...]:
-        """Args of the expression as a tuple of Sym."""
+        """Args of the expression as a tuple."""
         cls = type(self)
         return tuple(cls(child) for child in self.rep.children[1:])
 

--- a/src/protosym/simplecas/matrix.py
+++ b/src/protosym/simplecas/matrix.py
@@ -138,7 +138,7 @@ class Matrix:
         # Use the element_graph rather than differentiating each element
         # separately.
         elements_diff = _diff_forward(self.elements_graph.rep, sym.rep)
-        new_elements = list(Expr(elements_diff).args)
+        new_elements: list[Expr] = list(Expr(elements_diff).args)  # pyright: ignore
         return self._new(self.nrows, self.ncols, new_elements, self.entrymap)
 
     def to_llvm_ir(self, symargs: list[Expr]) -> str:


### PR DESCRIPTION
Fixes most errors/warnings seen when using the pyright type checker.

The remaining warnings are related to TreeAtom:
```console
$ .local/node_modules/.bin/pyright src/protosym
No configuration file found.
pyproject.toml file found at /home/oscar/current/active/protosym.
Loading pyproject.toml file at /home/oscar/current/active/protosym/pyproject.toml
Pyproject file "/home/oscar/current/active/protosym/pyproject.toml" is missing "[tool.pyright]" section.
Assuming Python platform Linux
Searching for source files
Found 15 source files
pyright 1.1.302
/home/oscar/current/active/protosym/src/protosym/core/evaluate.py
  /home/oscar/current/active/protosym/src/protosym/core/evaluate.py:42:41 - warning: TypeVar "_S" appears only once in generic function signature (reportInvalidTypeVarUse)
  /home/oscar/current/active/protosym/src/protosym/core/evaluate.py:95:43 - error: Type variable "_S" has no meaning in this context (reportGeneralTypeIssues)
  /home/oscar/current/active/protosym/src/protosym/core/evaluate.py:130:40 - warning: TypeVar "_S" appears only once in generic function signature (reportInvalidTypeVarUse)
1 error, 2 warnings, 0 informations 
Completed in 7.392sec
```
These are related to the fact that `TreeAtom` does not really do anything with its type parameter. I think that maybe there is no point in TreeAtom having a type parameter. If that is the case then probably what should really be done is to get rid of TreeAtom and TreeNode and just have Tree. That's for a separate PR though.