### PR TITLE
refactor(core): merge Tree* classes into Tree

### DIFF
--- a/src/protosym/core/atom.py
+++ b/src/protosym/core/atom.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 AnyValue = _Hashable
-_T = _TypeVar("_T", bound=AnyValue)
+_T = _TypeVar("_T", bound=AnyValue, covariant=True)
 
 #
 # The global store of Atoms. This maps from AtomTypes and values to Atoms.
@@ -66,8 +66,7 @@ class AtomType(_Generic[_T]):
     ========
 
     Atom: The actual instances of atomic expressions.
-    protosym.core.tree.TreeAtom: The :class:`TreeExpr` representation of atomic
-        expressions.
+    protosym.core.tree.Tree: Type that often wraps an :class:`Atom`.
     """
 
     __slots__ = (
@@ -92,7 +91,7 @@ class AtomType(_Generic[_T]):
         """Name of the Atom as a string."""
         return self.name
 
-    def __call__(self, value: _T) -> Atom[_T]:
+    def __call__(self, value: _T) -> Atom[_T]:  # type: ignore
         """Create an Atom of this type."""
         return Atom(self, value)
 
@@ -108,9 +107,9 @@ class Atom(_Generic[_T]):
     do hold an internal value but it is not considered to be a child in the
     sense of the ``children`` that other nodes of the expression graph have.
 
-    Every :class:`Atom` has both an :class:`AtomType` and an internal ``value``. An
-    :class:`Atom` is not intended to be constructed directly but rather is created
-    by calling an :class:`AtomType`.
+    Every :class:`Atom` has both an :class:`AtomType` and an internal
+    ``value``. An :class:`Atom` is not intended to be constructed directly but
+    rather is created by calling an :class:`AtomType`.
 
     >>> from protosym.core.atom import AtomType, Atom
     >>> Integer = AtomType('Integer', int)
@@ -130,14 +129,14 @@ class Atom(_Generic[_T]):
     >>> type(one.value)
     <class 'int'>
 
-    We can rebuild the :class:`Atom` from its ``atom_type`` and ``value``. This is
-    useful if we want to make an atom with a modified ``value``. Giving exactly
-    the same ``value`` will return precisely the same object because there can
-    only be a unique copy of an atom with any given ``atom_type`` and
-    ``value``. A global store is used to ensure that creating a new :class:`Atom` of
-    the same :class:`AtomType` and ``value`` will always return the same object.
-    For this to work the value used to construct an :class:`Atom` is required to be
-    hashable.
+    We can rebuild the :class:`Atom` from its ``atom_type`` and ``value``. This
+    is useful if we want to make an atom with a modified ``value``. Giving
+    exactly the same ``value`` will return precisely the same object because
+    there can only be a unique copy of an atom with any given ``atom_type`` and
+    ``value``. A global store is used to ensure that creating a new
+    :class:`Atom` of the same :class:`AtomType` and ``value`` will always
+    return the same object. For this to work the value used to construct an
+    :class:`Atom` is required to be hashable.
 
     >>> one == one.atom_type(one.value)
     True
@@ -146,16 +145,15 @@ class Atom(_Generic[_T]):
     >>> Integer(2) is Integer(2)
     True
 
-    Apart from holding a reference to the :class:`AtomType` and also the internal
-    value the only property that an :class:`Atom` has is that it can be compared to
-    other objects with `==` and is itself hashable.
+    Apart from holding a reference to the :class:`AtomType` and also the
+    internal value the only property that an :class:`Atom` has is that it can
+    be compared to other objects with `==` and is itself hashable.
 
     See Also
     ========
 
     AtomType: The class of types of :class:`Atom`.
-    protosym.core.tree.TreeAtom: The higher-level :class:`TreeExpr`
-        representation of an :class:`Atom`.
+    protosym.core.tree.Tree: Type that often wraps an :class:`Atom`.
     """
 
     __slots__ = (

--- a/src/protosym/simplecas/sympy_conversions.py
+++ b/src/protosym/simplecas/sympy_conversions.py
@@ -44,8 +44,8 @@ sympy_sin = PyOp1[sympy.Basic](sympy.sin)  # pyright: ignore
 sympy_cos = PyOp1[sympy.Basic](sympy.cos)  # pyright: ignore
 sympy_tuple = PyOpN[sympy.Basic](lambda a: sympy.Tuple(*a))  # pyright: ignore
 sympy_undef_call = HeadOp[sympy.Basic](
-    lambda a, b: sympy.Function(str(a))(*b)
-)  # pyright: ignore
+    lambda a, b: sympy.Function(str(a))(*b)  # pyright: ignore
+)
 
 eval_to_sympy[Integer[a]] = sympy_integer(a)
 eval_to_sympy[Symbol[a]] = sympy_symbol(a)

--- a/tests/core/test_evaluate.py
+++ b/tests/core/test_evaluate.py
@@ -8,8 +8,8 @@ from protosym.core.evaluate import Evaluator
 from protosym.core.evaluate import Transformer
 from protosym.core.exceptions import NoEvaluationRuleError
 from protosym.core.tree import funcs_symbols
-from protosym.core.tree import TreeAtom
-from protosym.core.tree import TreeExpr
+from protosym.core.tree import Tr
+from protosym.core.tree import Tree
 
 
 def test_Evaluator() -> None:
@@ -17,13 +17,13 @@ def test_Evaluator() -> None:
     Integer = AtomType("Integer", int)
     Function = AtomType("Function", str)
     Symbol = AtomType("Symbol", str)
-    one = TreeAtom(Integer(1))
-    two = TreeAtom(Integer(2))
-    cos = TreeAtom(Function("cos"))
-    sin = TreeAtom(Function("sin"))
-    Pow = TreeAtom(Function("Pow"))
-    Add = TreeAtom(Function("Add"))
-    x = TreeAtom(Symbol("x"))
+    one = Tr(Integer(1))
+    two = Tr(Integer(2))
+    cos = Tr(Function("cos"))
+    sin = Tr(Function("sin"))
+    Pow = Tr(Function("Pow"))
+    Add = Tr(Function("Add"))
+    x = Tr(Symbol("x"))
 
     eval_f64 = Evaluator[float]()
     eval_f64.add_atom(Integer, float)
@@ -32,7 +32,7 @@ def test_Evaluator() -> None:
     eval_f64.add_op2(Pow, pow)
     eval_f64.add_opn(Add, math.fsum)
 
-    test_cases: list[tuple[TreeExpr, dict[TreeExpr, float], float]] = [
+    test_cases: list[tuple[Tree, dict[Tree, float], float]] = [
         (sin(cos(one)), {}, 0.5143952585235492),
         (sin(cos(x)), {x: 1.0}, 0.5143952585235492),
         (Add(Pow(sin(one), two), Pow(cos(one), two)), {}, 1.0),
@@ -45,7 +45,7 @@ def test_Evaluator() -> None:
             assert eval_f64(expr) == expected
 
     # Test all implementations
-    eval_funcs: list[Callable[[TreeExpr, dict[TreeExpr, float]], float]] = [
+    eval_funcs: list[Callable[[Tree, dict[Tree, float]], float]] = [
         eval_f64,
         eval_f64.evaluate,
         eval_f64.eval_recursive,
@@ -60,7 +60,7 @@ def test_Transformer() -> None:
     """Test defining and using a Transformer."""
     [f, g], [x, y] = funcs_symbols(["f", "g"], ["x", "y"])
 
-    # A Transformer is an Evaluator that evaluates to a TreeExpr and provides
+    # A Transformer is an Evaluator that evaluates to a Tree and provides
     # defaults.
     f2g = Transformer()
     f2g.add_opn(f, lambda args: g(*args))
@@ -68,7 +68,7 @@ def test_Transformer() -> None:
     assert f2g(expr) == g(g(x, g(y)), y)
 
     # With Evaluator the above would fail without rules for Symbol and g:
-    f2g_eval = Evaluator[TreeExpr]()
+    f2g_eval = Evaluator[Tree]()
     f2g_eval.add_opn(f, lambda args: g(*args))
 
     # We need a rule for unknown atoms:

--- a/tests/core/test_sym.py
+++ b/tests/core/test_sym.py
@@ -19,7 +19,7 @@ from protosym.core.sym import star
 from protosym.core.sym import Sym
 from protosym.core.sym import SymAtomType
 from protosym.core.sym import SymEvaluator
-from protosym.core.tree import TreeAtom
+from protosym.core.tree import Tree
 
 
 class Expr(Sym):
@@ -72,7 +72,7 @@ def test_Sym() -> None:
     """Test a few properties of Sym separately."""
     s_one = Sym.new_atom("Integer", int)(1)
     assert str(s_one) == "1"
-    assert repr(s_one) == "Sym(TreeAtom(Integer(1)))"
+    assert repr(s_one) == "Sym(Tr(Integer(1)))"
 
 
 def test_Sym_str() -> None:
@@ -105,7 +105,7 @@ def test_Sym_types() -> None:
     assert type(Function) is SymAtomType
     assert type(cos) is Expr
     assert type(Add) is Expr
-    assert type(cos.rep) is TreeAtom
+    assert type(cos.rep) is Tree
     assert type(a) == type(b) == Expr
 
 

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -1,3 +1,5 @@
+from pytest import raises
+
 from protosym.core.atom import Atom
 from protosym.core.atom import AtomType
 from protosym.core.tree import forward_graph
@@ -5,68 +7,70 @@ from protosym.core.tree import ForwardGraph
 from protosym.core.tree import funcs_symbols
 from protosym.core.tree import topological_sort
 from protosym.core.tree import topological_split
-from protosym.core.tree import TreeAtom
-from protosym.core.tree import TreeExpr
-from protosym.core.tree import TreeNode
+from protosym.core.tree import Tr
+from protosym.core.tree import Tree
 
 
-def test_TreeExpr_basic() -> None:
-    """Test basic construction and equality of TreeExpr."""
+def test_Tree_basic() -> None:
+    """Test basic construction and equality of Tree."""
     Integer = AtomType("Integer", int)
     Function = AtomType("Function", str)
     one_atom = Integer(1)
     f_atom = Function("f")
 
-    one_tree = TreeAtom(one_atom)
-    f_tree = TreeAtom(f_atom)
+    one_tree = Tr(one_atom)
+    f_tree = Tr(f_atom)
     f_one = f_tree(one_tree)
 
     assert str(one_tree) == "1"
     assert str(f_tree) == "f"
     assert str(f_one) == "f(1)"
 
-    assert repr(one_tree) == "TreeAtom(Integer(1))"
-    assert repr(f_tree) == "TreeAtom(Function('f'))"
-    assert repr(f_one) == "TreeNode(TreeAtom(Function('f')), TreeAtom(Integer(1)))"
+    assert repr(one_tree) == "Tr(Integer(1))"
+    assert repr(f_tree) == "Tr(Function('f'))"
+    assert repr(f_one) == "Tree(Tr(Function('f')), Tr(Integer(1)))"
 
     assert not isinstance(f_one, Atom)
     assert not isinstance(f_tree, Atom)
-    assert isinstance(f_tree, TreeAtom)
-    assert isinstance(f_tree, TreeExpr)
-    assert isinstance(one_tree, TreeAtom)
-    assert isinstance(one_tree, TreeExpr)
-    assert isinstance(f_one, TreeNode)
-    assert isinstance(f_one, TreeExpr)
+    assert isinstance(f_tree, Tree)
+    assert isinstance(f_tree, Tree)
+    assert isinstance(one_tree, Tree)
+    assert isinstance(one_tree, Tree)
+    assert isinstance(f_one, Tree)
+    assert isinstance(f_one, Tree)
 
     assert (one_tree == one_tree) is True
     assert (f_tree == f_tree) is True
     assert (f_one == f_one) is True
-    assert (one_tree == f_tree) is False  # type: ignore[comparison-overlap]
+    assert (one_tree == f_tree) is False
     assert (one_tree == one_atom) is False  # type: ignore[comparison-overlap]
 
     assert (one_tree != one_tree) is False
     assert (f_tree != f_tree) is False
     assert (f_one != f_one) is False
-    assert (one_tree != f_tree) is True  # type: ignore[comparison-overlap]
+    assert (one_tree != f_tree) is True
     assert (one_tree != one_atom) is True  # type: ignore[comparison-overlap]
 
-    assert TreeAtom(one_atom) is TreeAtom(one_atom)
+    assert Tr(one_atom) is Tr(one_atom)
     assert f_tree(one_tree) is f_tree(one_tree)
+
+    raises(TypeError, lambda: Tree(1))  # type: ignore
+    raises(TypeError, lambda: Tr(1))  # type: ignore
 
 
 def test_funcs_symbols() -> None:
     """Test the funcs_symbols convenience function."""
     [f, g], [x, y] = funcs_symbols(["f", "g"], ["x", "y"])
-    assert all(isinstance(e, TreeAtom) for e in [f, g, x, y])
+    assert all(isinstance(e, Tree) for e in [f, g, x, y])
 
 
 def test_topological_sort_split() -> None:
     """Simple tests for topological_sort and topological_split."""
     Function = AtomType("Function", str)
     Symbol = AtomType("Symbol", str)
-    f = TreeAtom(Function("f"))
-    x = TreeAtom(Symbol("x"))
-    y = TreeAtom(Symbol("y"))
+    f = Tr(Function("f"))
+    x = Tr(Symbol("x"))
+    y = Tr(Symbol("y"))
 
     expr = f(f(x, y), f(f(x), f(x, y)))
     subexpressions = [


### PR DESCRIPTION
Previously it seemed to make sense to have separate classes TreeExpr, TreeNode and TreeAtom. The main reason for the distinction was so that TreeAtom could be generically typed with a rtype parameter indicating the type of the values stored in the atom. This turns out not to be very useful though and the three separate classes are an unnecessary complexity.

This commit merges the three classes TreeExpr, TreeNode and TreeAtom into a single Tree class. The instances of this class have two attributes value and children. The two possibilities are that value=None and children is a tuple ot Tree or that value is not None and children is the empty tuple. This more naturally corresponds to the Rust implementation in which Tree is represented as an enum with two variants.