### PR TITLE
fix(docs): make sphinx report a failed build

### DIFF
--- a/docs/reference/core_types.rst
+++ b/docs/reference/core_types.rst
@@ -11,13 +11,7 @@ Core types
 
 .. automodule:: protosym.core.tree
 
-.. autoclass:: protosym.core.tree::TreeExpr
-    :members:
-
-.. autoclass:: protosym.core.tree::TreeAtom
-    :members:
-
-.. autoclass:: protosym.core.tree::TreeNode
+.. autoclass:: protosym.core.tree::Tree
     :members:
 
 .. autofunction:: protosym.core.tree::funcs_symbols

--- a/noxfile.py
+++ b/noxfile.py
@@ -187,7 +187,7 @@ def xdoctest(session: Session) -> None:
 @session(name="docs-build", python="3.9")
 def docs_build(session: Session) -> None:
     """Build the documentation."""
-    args = session.posargs or ["docs", "docs/_build"]
+    args = session.posargs or ["-W", "docs", "docs/_build"]
     session.install(".")
     session.install("sphinx", "sphinx-rtd-theme")
 


### PR DESCRIPTION
The docs build broke after #69.

This will be two commits. The first is to verify that CI fails properly when the build fails. The second followup will be a fix to the docs so that they build.