### PR TITLE
Refactor differentiation, add as_function and xreplace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .venv
 node_modules
 my
+.DS_Store

--- a/src/protosym/core/differentiate.py
+++ b/src/protosym/core/differentiate.py
@@ -1,0 +1,139 @@
+"""Core routines for differentiating at Tree level.
+
+This module implements the basic forward differentiation algorithm. Higher
+level code in the sym module wraps this to make a nicer pattern-matching style
+interface for specifying differentiation rules.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from typing import TYPE_CHECKING as _TYPE_CHECKING
+
+from protosym.core.tree import forward_graph
+
+
+__all__ = [
+    "DiffProperties",
+    "diff_forward",
+]
+
+
+if _TYPE_CHECKING:
+    from protosym.core.tree import Tree, SubsFunc
+
+    _DiffRules = dict[tuple[Tree, int], SubsFunc]
+
+
+@dataclass(frozen=True)
+class DiffProperties:
+    """Collection of properties needed for differentiation."""
+
+    zero: Tree
+    one: Tree
+    add: Tree
+    mul: Tree
+    distributive: set[Tree] = field(default_factory=set)
+    diff_rules: _DiffRules = field(default_factory=dict)
+
+    def add_distributive(self, head: Tree) -> None:
+        """Add a distributive rule :math:`f(x, y)' = f(x', y')`."""
+        self.distributive.add(head)
+
+    def add_diff_rule(self, head: Tree, argnum: int, func: SubsFunc) -> None:
+        """Add an elementary rule like :math:`sin(x)' = cos(x)`."""
+        self.diff_rules[head, argnum] = func
+
+
+def diff_forward(
+    expression: Tree,
+    sym: Tree,
+    prop: DiffProperties,
+) -> Tree:
+    """Derivative of expression wrt sym.
+
+    Uses forward accumulation algorithm.
+    """
+    one = prop.one
+    zero = prop.zero
+    add = prop.add
+    mul = prop.mul
+    distributive = prop.distributive
+    diff_rules = prop.diff_rules
+
+    graph = forward_graph(expression)
+
+    stack = list(graph.atoms)
+    diff_stack = [one if expr == sym else zero for expr in stack]
+
+    for func, indices in graph.operations:
+        args = [stack[i] for i in indices]
+        diff_args = [diff_stack[i] for i in indices]
+        expr = func(*args)
+
+        if func in distributive:
+            diff_terms = [func(*diff_args)]
+        elif set(diff_args) == {zero}:
+            # XXX: This could return the wrong thing if the expression has an
+            # unrecognised head and does not represent a number.
+            diff_terms = []
+        elif func == add:
+            diff_terms = [da for da in diff_args if da != zero]
+        elif func == mul:
+            diff_terms = product_rule_forward(args, diff_args, zero, mul)
+        else:
+            diff_terms = chain_rule_forward(
+                func, args, diff_args, zero, one, mul, diff_rules
+            )
+
+        if not diff_terms:
+            derivative = zero
+        elif len(diff_terms) == 1:
+            derivative = diff_terms[0]
+        else:
+            derivative = add(*diff_terms)
+
+        stack.append(expr)
+        diff_stack.append(derivative)
+
+    # At this point stack is a topological sort of expr and diff_stack is the
+    # list of derivatives of every subexpression in expr. At the top of the
+    # stack is expr and its derivative is at the top of diff_stack.
+    return diff_stack[-1]
+
+
+def product_rule_forward(
+    args: list[Tree],
+    diff_args: list[Tree],
+    zero: Tree,
+    mul: Tree,
+) -> list[Tree]:
+    """Product rule in forward accumulation."""
+    terms: list[Tree] = []
+    for n, diff_arg in enumerate(diff_args):
+        if diff_arg != zero:
+            # XXX: Maybe check if diff_arg == 1 here?
+            term = mul(*args[:n], diff_arg, *args[n + 1 :])
+            terms.append(term)
+    return terms
+
+
+def chain_rule_forward(
+    func: Tree,
+    args: list[Tree],
+    diff_args: list[Tree],
+    zero: Tree,
+    one: Tree,
+    mul: Tree,
+    diff_rules: _DiffRules,
+) -> list[Tree]:
+    """Chain rule in forward accumulation."""
+    terms: list[Tree] = []
+    for n, diff_arg in enumerate(diff_args):
+        if diff_arg != zero:
+            pdiff = diff_rules[(func, n)]
+            diff_term = pdiff(*args)
+            if diff_arg != one:
+                diff_term = mul(diff_term, diff_arg)
+            terms.append(diff_term)
+    return terms

--- a/src/protosym/core/tree.py
+++ b/src/protosym/core/tree.py
@@ -263,7 +263,10 @@ def topological_sort(
         seen = set()
 
     expressions = []
-    stack = [(expression, get_children(expression))]
+    stack = []
+
+    if expression not in seen:
+        stack = [(expression, get_children(expression))]
 
     while stack:
         top, children = stack[-1]
@@ -482,8 +485,12 @@ class SubsFunc:
             else:
                 atoms.append(subexpr)
 
-        # Prune atoms that are not a child of any node.
-        atoms = [a for a in atoms if a in node_children]
+        if atoms and not nodes:
+            # We get here if the expression does not depend on the args.
+            atoms = [expr]
+        else:
+            # Prune atoms that are not a child of any node.
+            atoms = [a for a in atoms if a in node_children]
 
         num_args = len(args)
         num_args_atoms = num_args + len(atoms)

--- a/src/protosym/core/tree.py
+++ b/src/protosym/core/tree.py
@@ -13,6 +13,7 @@ from protosym.core.atom import AtomType
 
 
 if _TYPE_CHECKING:
+    from typing import Optional
     from protosym.core.atom import AnyAtom
 
 
@@ -195,7 +196,12 @@ def funcs_symbols(
     return functions, symbols
 
 
-def topological_sort(expression: Tree, *, heads: bool = False) -> list[Tree]:
+def topological_sort(
+    expression: Tree,
+    *,
+    heads: bool = False,
+    exclude: Optional[set[Tree]] = None,
+) -> list[Tree]:
     """List of subexpressions of a :class:`Tree` sorted topologically.
 
     Create some functions and symbols and use them to make an expression:
@@ -251,7 +257,11 @@ def topological_sort(expression: Tree, *, heads: bool = False) -> list[Tree]:
             children = expr.children[1:]
         return list(children)[::-1]
 
-    seen = set()
+    if exclude is not None:
+        seen = set(exclude)
+    else:
+        seen = set()
+
     expressions = []
     stack = [(expression, get_children(expression))]
 
@@ -272,6 +282,8 @@ def topological_sort(expression: Tree, *, heads: bool = False) -> list[Tree]:
 
 def topological_split(
     expr: Tree,
+    *,
+    exclude: Optional[set[Tree]] = None,
 ) -> tuple[list[Tree], set[Tree], list[Tree]]:
     """Topological sort split into atoms, heads and compound expressions.
 
@@ -302,7 +314,7 @@ def topological_split(
     Tree: The expression class that this operates on.
     topological_sort: Topological sort as a list of all subexpressions.
     """
-    subexpressions = topological_sort(expr)
+    subexpressions = topological_sort(expr, exclude=exclude)
 
     atoms: list[Tree] = []
     heads: set[Tree] = set()
@@ -394,3 +406,115 @@ class ForwardGraph:
     atoms: list[Tree]
     heads: set[Tree]
     operations: list[tuple[Tree, list[int]]]
+
+
+class SubsFunc:
+    """Callable for performing substitutions into a Tree.
+
+    We first make some symbols and an expression:
+
+    >>> from protosym.core.tree import funcs_symbols
+    >>> [f, g, h], [x, y, z] = funcs_symbols(['f', 'g', 'h'], ['x', 'y', 'z'])
+    >>> expr = h(g(x, y), f(x, y))
+
+    Now we can make a :class:`SubsFunc` for substituting `y` and replacing it
+    with some other expression:
+
+    >>> subsy = SubsFunc(expr, [y])
+    >>> print(expr)
+    h(g(x, y), f(x, y))
+    >>> print(subsy(z))
+    h(g(x, z), f(x, z))
+
+    We can also substitute non-atomic expressions:
+
+    >>> subs_fxy = SubsFunc(expr, [f(x, y)])
+    >>> print(expr)
+    h(g(x, y), f(x, y))
+    >>> print(subs_fxy(z))
+    h(g(x, y), z)
+
+    Overlapping substitutions are handled because all substitutions are
+    perfomed simultaneously:
+
+    >>> subs_gxy_x = SubsFunc(expr, [g(x, y), x])
+    >>> print(expr)
+    h(g(x, y), f(x, y))
+    >>> print(subs_gxy_x(z, g(z)))
+    h(z, f(g(z), y))
+
+    Creating a :class:`SubsFunc` is more expensive than calling it to perform
+    the substitution so the intended use is for a situation in which the same
+    :class:`SubsFunc` will be reused for many calls to replace the same values
+    from one expression with different replacement values.
+    """
+
+    nargs: int
+    atoms: list[Tree]
+    operations: list[list[int]]
+
+    def __new__(cls, expr: Tree, args: list[Tree]) -> SubsFunc:
+
+        # A topological sort but exluding the args because they will be
+        # replaced in the substitution anyway.
+        subexpressions = topological_sort(expr, heads=True, exclude=set(args))
+
+        atoms = []
+        nodes = []
+
+        has_args = set(args)
+        node_children = set()
+
+        for subexpr in subexpressions:
+            children = subexpr.children
+            if children:
+                children_set = set(children)
+                if children_set & has_args:
+                    has_args.add(subexpr)
+                    node_children.update(children_set)
+                    nodes.append(subexpr)
+                else:
+                    # This node does not include args in its indirect children
+                    # so the substitution would not change its value. We treat
+                    # it then as an atomic expression for the purpose of
+                    # performing the substtution.
+                    atoms.append(subexpr)
+            else:
+                atoms.append(subexpr)
+
+        # Prune atoms that are not a child of any node.
+        atoms = [a for a in atoms if a in node_children]
+
+        num_args = len(args)
+        num_args_atoms = num_args + len(atoms)
+
+        indices: dict[Tree, int] = dict(zip(args, range(num_args)))
+        indices.update(dict(zip(atoms, range(num_args, num_args_atoms))))
+
+        operations = []
+        for index, node in enumerate(nodes, num_args_atoms):
+            indices[node] = index
+            child_indices = [indices[c] for c in node.children]
+            operations.append(child_indices)
+
+        obj = super().__new__(cls)
+        obj.nargs = num_args
+        obj.atoms = atoms
+        obj.operations = operations
+
+        return obj
+
+    def __call__(self, *args: Tree) -> Tree:
+        return self.call(args)
+
+    def call(self, args: tuple[Tree, ...]) -> Tree:
+        if len(args) != self.nargs:
+            raise TypeError("Wrong number of arguments")
+
+        stack = list(args) + self.atoms
+
+        for indices in self.operations:
+            children = [stack[i] for i in indices]
+            stack.append(Tree(*children))
+
+        return stack[-1]

--- a/src/protosym/simplecas/__init__.py
+++ b/src/protosym/simplecas/__init__.py
@@ -7,6 +7,7 @@ from .expr import Add
 from .expr import b
 from .expr import bin_expand
 from .expr import cos
+from .expr import diff
 from .expr import Expr
 from .expr import expressify
 from .expr import f
@@ -29,6 +30,7 @@ from .matrix import Matrix
 
 __all__ = [
     "expressify",
+    "diff",
     "Expr",
     "Matrix",
     "Function",

--- a/src/protosym/simplecas/expr.py
+++ b/src/protosym/simplecas/expr.py
@@ -16,6 +16,7 @@ from protosym.core.sym import HeadOp
 from protosym.core.sym import HeadRule
 from protosym.core.sym import Sym
 from protosym.core.tree import forward_graph
+from protosym.core.tree import SubsFunc
 from protosym.core.tree import topological_sort
 from protosym.simplecas.exceptions import ExpressifyError
 
@@ -174,6 +175,21 @@ class Expr(Sym):
         args_expr = [expressify(arg) for arg in args]
         args_rep = [arg.rep for arg in args_expr]
         return Expr(self.rep(*args_rep))
+
+    def xreplace(self, reps: dict[Expressifiable, Expressifiable]) -> Expr:
+        """Replace subexpressions in an :class:`Expr`.
+
+        >>> from protosym.simplecas import cos, x, y
+        >>> e = cos(x) + x
+        >>> e.xreplace({x:y})
+        (cos(y) + y)
+        >>> e.xreplace({cos(x): x, x: y})
+        (x + y)
+        """
+        args = [expressify(old).rep for old in reps.keys()]
+        vals = [expressify(new).rep for new in reps.values()]
+        func = SubsFunc(self.rep, args)
+        return Expr(func(*vals))
 
     def __pos__(self) -> Expr:
         """+Expr -> Expr."""

--- a/src/protosym/simplecas/matrix.py
+++ b/src/protosym/simplecas/matrix.py
@@ -5,7 +5,6 @@ from typing import Any
 from typing import Sequence
 from typing import TYPE_CHECKING as _TYPE_CHECKING
 
-from protosym.simplecas.expr import _diff_forward
 from protosym.simplecas.expr import Add
 from protosym.simplecas.expr import Expr
 from protosym.simplecas.expr import expressify
@@ -137,8 +136,8 @@ class Matrix:
             raise TypeError("Differentiation var should be a symbol.")
         # Use the element_graph rather than differentiating each element
         # separately.
-        elements_diff = _diff_forward(self.elements_graph.rep, sym.rep)
-        new_elements: list[Expr] = list(Expr(elements_diff).args)  # pyright: ignore
+        elements_diff = self.elements_graph.diff(sym)
+        new_elements: list[Expr] = list(elements_diff.args)
         return self._new(self.nrows, self.ncols, new_elements, self.entrymap)
 
     def to_llvm_ir(self, symargs: list[Expr]) -> str:

--- a/tests/core/test_differentiate.py
+++ b/tests/core/test_differentiate.py
@@ -1,0 +1,53 @@
+from protosym.core.atom import AtomType
+from protosym.core.differentiate import diff_forward
+from protosym.core.differentiate import DiffProperties
+from protosym.core.tree import SubsFunc
+from protosym.core.tree import Tr
+
+
+def test_core_differentiate() -> None:
+    """Test elementary differentiation routines."""
+    Integer = AtomType("Integer", int)
+    Function = AtomType("Function", str)
+    Symbol = AtomType("Symbol", str)
+
+    zero = Tr(Integer(0))
+    one = Tr(Integer(1))
+    negone = Tr(Integer(-1))
+
+    sin = Tr(Function("sin"))
+    cos = Tr(Function("cos"))
+    Vector = Tr(Function("Vector"))
+    Add = Tr(Function("Add"))
+    Mul = Tr(Function("Mul"))
+    Pow = Tr(Function("Pow"))
+
+    x = Tr(Symbol("x"))
+    y = Tr(Symbol("y"))
+
+    prop = DiffProperties(zero=zero, one=one, add=Add, mul=Mul)
+
+    assert diff_forward(zero, x, prop) == zero
+    assert diff_forward(x, x, prop) == one
+    assert diff_forward(x, y, prop) == zero
+    assert diff_forward(Add(x, y), x, prop) == one
+    assert diff_forward(Add(y, y), x, prop) == zero
+    assert diff_forward(Mul(x, y), y, prop) == Mul(x, one)
+    assert diff_forward(Mul(x, y), x, prop) == Mul(one, y)
+    assert diff_forward(Mul(x, y), x, prop) == Mul(one, y)
+
+    prop.add_distributive(Vector)
+
+    assert diff_forward(Vector(x, y), x, prop) == Vector(one, zero)
+
+    prop.add_diff_rule(Pow, 0, SubsFunc(Mul(y, Pow(x, Add(y, negone))), [x, y]))
+    prop.add_diff_rule(sin, 0, SubsFunc(cos(x), [x]))
+    prop.add_diff_rule(cos, 0, SubsFunc(Mul(negone, sin(x)), [x]))
+
+    assert diff_forward(Pow(x, y), x, prop) == Mul(y, Pow(x, Add(y, negone)))
+    assert diff_forward(sin(x), x, prop) == cos(x)
+    assert diff_forward(sin(sin(x)), x, prop) == Mul(cos(sin(x)), cos(x))
+    assert diff_forward(sin(sin(y)), x, prop) == zero
+    assert diff_forward(Add(sin(x), cos(x)), x, prop) == Add(
+        cos(x), Mul(negone, sin(x))
+    )

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -131,4 +131,10 @@ def test_subsfunc() -> None:
     subs = SubsFunc(expr, [f(x, y)])
     assert subs(z) == f(z, g(y))
 
+    subs = SubsFunc(expr, [expr])
+    assert subs(t) == t
+
+    subs = SubsFunc(expr, [t])
+    assert subs(z) == expr
+
     raises(TypeError, lambda: subs(z, t))

--- a/tests/core/test_tree.py
+++ b/tests/core/test_tree.py
@@ -5,6 +5,7 @@ from protosym.core.atom import AtomType
 from protosym.core.tree import forward_graph
 from protosym.core.tree import ForwardGraph
 from protosym.core.tree import funcs_symbols
+from protosym.core.tree import SubsFunc
 from protosym.core.tree import topological_sort
 from protosym.core.tree import topological_split
 from protosym.core.tree import Tr
@@ -87,6 +88,16 @@ def test_topological_sort_split() -> None:
     assert topological_sort(expr, heads=False) == subexpressions[1:]
     assert topological_sort(expr, heads=True) == subexpressions
 
+    # Test generating a topological sort that excludes f(x, y).
+    # This also excludes children like y that do not appear elsewhere.
+    expected_exclude = [
+        x,
+        f(x),
+        f(f(x), f(x, y)),
+        f(f(x, y), f(f(x), f(x, y))),
+    ]
+    assert topological_sort(expr, exclude={f(x, y)}) == expected_exclude
+
     expected_split = (
         [x, y],
         {f},
@@ -108,3 +119,16 @@ def test_forward_graph() -> None:
     )
 
     assert forward_graph(expr) == expected
+
+
+def test_subsfunc() -> None:
+    """Test basic functionality of SubsFunc."""
+    [f, g], [x, y, z, t] = funcs_symbols(["f", "g"], ["x", "y", "z", "t"])
+    expr = f(f(x, y), g(y))
+    subs = SubsFunc(expr, [x, y])
+    assert subs(z, t) == f(f(z, t), g(t))
+
+    subs = SubsFunc(expr, [f(x, y)])
+    assert subs(z) == f(z, g(y))
+
+    raises(TypeError, lambda: subs(z, t))

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -63,6 +63,17 @@ def test_simplecas_identity() -> None:
         assert e1 is e2
 
 
+def test_xreplace() -> None:
+    """Test simple substitutions with xreplace."""
+    expr = x**2 + 1
+    assert expr.xreplace({x: 1}) == Integer(1) ** 2 + 1
+    assert expr.xreplace({x: y}) == y**2 + 1
+    assert expr.xreplace({x**2: y}) == y + 1
+    assert expr.xreplace({x**2 + 1: y}) == y
+    assert expr.xreplace({y: 1}) == x**2 + 1
+    assert expr.xreplace({1: 2}) == x**2 + 2
+
+
 def test_simplecas_operations() -> None:
     """Test arithmetic operations with Expr."""
     assert +x == x
@@ -157,8 +168,8 @@ def test_simplecas_to_sympy() -> None:
     test_cases = [
         (sin(x), sinx_sym),
         (cos(x), cosx_sym),
-        (cos(x) ** 2 + sin(x) ** 2, cosx_sym**2 + sinx_sym**2),
-        (cos(x) * sin(x), cosx_sym * sinx_sym),
+        (cos(x) ** 2 + sin(x) ** 2, cosx_sym**2 + sinx_sym**2),  # pyright: ignore
+        (cos(x) * sin(x), cosx_sym * sinx_sym),  # pyright: ignore
         (f(x), f_sym(x_sym)),
     ]
     for expr, sympy_expr in test_cases:
@@ -203,7 +214,7 @@ def test_simplecas_to_sympy_matrix() -> None:
     x_sym = sympy.Symbol("x")
     sinx_sym = sympy.sin(x_sym)
     cosx_sym = sympy.cos(x_sym)
-    M = sympy.Matrix([[sinx_sym, cosx_sym], [-cosx_sym, sinx_sym]])
+    M = sympy.Matrix([[sinx_sym, cosx_sym], [-cosx_sym, sinx_sym]])  # pyright: ignore
     assert M == Matrix.from_sympy(M).to_sympy()
 
 

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -117,6 +117,17 @@ def test_simplecas_expressify() -> None:
     raises(ExpressifyError, lambda: expressify([]))
 
 
+def test_simplecas_as_function() -> None:
+    """Basic test for as_function."""
+    assert cos(x).as_function(x)(1) == cos(1)
+    assert cos(x + y).as_function(x)(1) == cos(1 + y)
+    assert cos(x + y).as_function(y)(1) == cos(x + 1)
+    assert (cos(x) + sin(y)).as_function(x, y)(1, 2) == cos(1) + sin(2)
+    assert (cos(x) + sin(y)).as_function(y, x)(1, 2) == cos(2) + sin(1)
+    assert cos(x).as_function(y)(1) == cos(x)
+    assert cos(x).as_function(cos(x))(1) == Integer(1)
+
+
 def test_simplecas_repr() -> None:
     """Test basic operations with simplecas."""
     assert str(Integer) == "Integer"

--- a/tests/test_simplecas.py
+++ b/tests/test_simplecas.py
@@ -2,11 +2,15 @@ from pytest import raises
 from pytest import skip
 
 from protosym.core.sym import SymAtomType
+from protosym.simplecas import a
 from protosym.simplecas import Add
+from protosym.simplecas import b
 from protosym.simplecas import cos
+from protosym.simplecas import diff
 from protosym.simplecas import Expr
 from protosym.simplecas import expressify
 from protosym.simplecas import f
+from protosym.simplecas import Function
 from protosym.simplecas import g
 from protosym.simplecas import Integer
 from protosym.simplecas import lambdify
@@ -278,6 +282,22 @@ def test_simplecas_differentation() -> None:
     assert (sin(x) + cos(x)).diff(x) == cos(x) + -1 * sin(x)
     assert (sin(x) ** 2).diff(x) == 2 * sin(x) ** Add(2, -1) * cos(x)
     assert (x * sin(x)).diff(x) == 1 * sin(x) + x * cos(x)
+
+
+def test_simplecas_differentiation_rules() -> None:
+    """Test setting new differentation rules."""
+    f = Function("f")
+    diff[f(a), a] = 1 + f(a) ** 2
+    assert diff(f(f(x)), x) == (1 + f(f(x)) ** 2) * (1 + f(x) ** 2)
+
+    def set_bad1() -> None:
+        diff[f(a), a, b] = f(a)  # type: ignore
+
+    def set_bad2() -> None:
+        diff[f(a, a), a] = f(a)
+
+    raises(TypeError, set_bad1)
+    raises(TypeError, set_bad2)
 
 
 def test_simplecas_bin_expand() -> None:


### PR DESCRIPTION
This PR refactors the differentiation code to move the main algorithm into the core so that it operates at a lower level. The end result is that in simplecas the differentation spec just looks like:
```python
diff = SymDifferentiator(Expr, add=Add, mul=Mul, zero=zero, one=one)
diff[sin(a), a] = cos(a)
diff[cos(a), a] = -sin(a)
diff[a**b, a] = b * a ** (b + (-1))  # what if b=0?
diff.add_distributive_rule(List)
```
To make this work with the pattern-ish rules I needed to add a function representation of an expression so you can do:
```python
In [5]: from protosym.simplecas import x, y, cos

In [6]: f = cos(x + y).as_function(x, y)

In [7]: f
Out[7]: <protosym.simplecas.expr.ExprFunction at 0x7fb7c960e860>

In [8]: f(1, 2)
Out[8]: cos((1 + 2))
```
That's needed to be able to rebuild the rhs after substituting in the args of the differentiated expression. This also makes it easy to implement `xreplace` so I added that as well:
```python
In [10]: cos(x + y).xreplace({x:1, y:2})
Out[10]: cos((1 + 2))
```