### PR TITLE
Add flatten function

### DIFF
--- a/src/protosym/core/differentiate.py
+++ b/src/protosym/core/differentiate.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from dataclasses import field
+from functools import reduce
 from typing import TYPE_CHECKING as _TYPE_CHECKING
 
 from protosym.core.tree import forward_graph
+from protosym.core.tree import Tr
 
 
 __all__ = [
@@ -20,9 +22,237 @@ __all__ = [
 
 
 if _TYPE_CHECKING:
+    from typing import Callable, Sequence
+    from protosym.core.atom import AtomType
     from protosym.core.tree import Tree, SubsFunc
 
     _DiffRules = dict[tuple[Tree, int], SubsFunc]
+
+
+@dataclass(frozen=True)
+class RingOps:
+    """Collection of ring operations."""
+
+    Integer: AtomType[int]
+    iadd: Callable[[int, int], int]
+    imul: Callable[[int, int], int]
+    add: Tree
+    mul: Tree
+    pow: Tree
+
+    def split_integers(self, args: Sequence[Tree]) -> tuple[list[int], list[Tree]]:
+        integers: list[int] = []
+        new_args: list[Tree] = []
+        for arg in args:
+            if not arg.children and (atom := arg.value).atom_type == self.Integer:
+                integers.append(atom.value)  # type: ignore
+            else:
+                new_args.append(arg)
+        return integers, new_args
+
+    def flatten_add(self, args: list[Tree]) -> Tree:
+        integers: list[int] = []
+        new_args: list[Tree] = []
+
+        # Associativity of add
+        # (x + y) + z -> x + y + z
+        for arg in args:
+            if arg.children and arg.children[0] == self.add:
+                new_args.extend(arg.children[1:])
+            else:
+                new_args.append(arg)
+
+        # Collect integer part
+        # x + 1 + 2 -> 3 + x
+        new_args2: list[Tree] = []
+        for arg in new_args:
+            if not arg.children and (atom := arg.value).atom_type == self.Integer:
+                integers.append(atom.value)  # type:ignore
+            else:
+                new_args2.append(arg)
+
+        # Process all muls, extracting their coefficients
+        # 2*x + 3*x -> 5*x
+        totals = {}
+        for arg in new_args2:
+            if arg.children and arg.children[0] == self.mul:
+                intfacs, factors = self.split_integers(arg.children[1:])
+                if len(factors) == 1:
+                    [fac] = factors
+                else:
+                    fac = self.mul(*factors)
+                integer = reduce(self.imul, intfacs, 1)
+                if fac not in totals:
+                    totals[fac] = 0
+                totals[fac] += integer
+            else:
+                if arg not in totals:
+                    totals[arg] = 0
+                totals[arg] += 1
+
+        new_args3: list[Tree] = []
+        for fac, c in totals.items():
+            if c == 0:
+                continue
+            elif c == 1:
+                new_args3.append(fac)
+            elif fac.children and fac.children[0] == self.mul:
+                new_args3.append(self.mul(Tr(self.Integer(c)), *fac.children[1:]))
+            else:
+                new_args3.append(self.mul(Tr(self.Integer(c)), fac))
+
+        int_value = reduce(self.iadd, integers, 0)
+
+        if int_value:
+            new_args3.insert(0, Tr(self.Integer(int_value)))
+
+        if not new_args3:
+            expr = Tr(self.Integer(0))
+        elif len(new_args3) == 1:
+            [expr] = new_args3
+        else:
+            expr = self.add(*new_args3)
+
+        return expr
+
+    def flatten_mul(self, args: list[Tree]) -> Tree:
+        integers: list[int] = []
+        new_args: list[Tree] = []
+
+        for arg in args:
+            if arg.children and arg.children[0] == self.mul:
+                new_args.extend(arg.children[1:])
+            else:
+                new_args.append(arg)
+
+        new_args2: list[Tree] = []
+        for arg in new_args:
+            if not arg.children and (atom := arg.value).atom_type == self.Integer:
+                integers.append(atom.value)  # type:ignore
+            else:
+                new_args2.append(arg)
+
+        powers = {}
+        for arg in new_args2:
+            if arg.children and arg.children[0] == self.pow:
+                base, s_exp = arg.children[1:]
+                exp: int
+                if s_exp.value.atom_type == self.Integer:
+                    exp = s_exp.value.value  # type: ignore
+                else:
+                    base, exp = arg, 1
+            else:
+                base, exp = arg, 1
+
+            if base not in powers:
+                powers[base] = 0
+            powers[base] += exp
+
+        new_args3: list[Tree] = []
+        for base, exp in powers.items():
+            if exp == 0:
+                continue
+            elif exp == 1:
+                new_args3.append(base)
+            else:
+                new_args3.append(self.pow(base, Tr(self.Integer(exp))))
+
+        int_value = reduce(self.imul, integers, 1)
+
+        if int_value == 0:
+            return Tr(self.Integer(int_value))
+        elif int_value != 1:
+            new_args3.insert(0, Tr(self.Integer(int_value)))
+
+        if not new_args3:
+            expr = Tr(self.Integer(1))
+        elif len(new_args3) == 1:
+            [expr] = new_args3
+        else:
+            expr = self.mul(*new_args3)
+
+        return expr
+
+    def flatten_pow(self, args: list[Tree]) -> Tree:
+        base, exponent = args
+
+        # (x**y)**a -> x**(a*y) for integer a
+        if base.children and base.children[0] == self.pow:
+            base_base, base_exp = base.children[1:]
+            if not exponent.children and exponent.value.atom_type == self.Integer:
+                exponent = self.flatten_mul([base_exp, exponent])
+                base = base_base
+
+        if exponent == Tr(self.Integer(0)):
+            expr = Tr(self.Integer(1))
+        elif exponent == Tr(self.Integer(1)):
+            expr = base
+        else:
+            expr = self.pow(base, exponent)
+        return expr
+
+    def flatten(self, expr: Tree) -> Tree:
+        """Apply the standard ring simplification rules.
+
+        Identity (addition): :math:`x + 0 = x`
+        Identity (multiplication): :math:`x * 1 = x`
+        Associativity (addition): :math:`(x + y) + z = x + (y + z)`
+        Associativity (multiplication): :math:`(x * y) * z = x * (y * z)`
+        Commutativity (addition): :math:`x + y = y + x`
+        Commutativity (multiplication): :math:`x * y = y * x`
+        Add to Mul: :math:`2*x + 3*x = 5*x`
+        Mul to Pow: :math:`x^2 * x^3 = x^5`
+        """
+        graph = forward_graph(expr)
+        stack = list(graph.atoms)
+        for func, indices in graph.operations:
+
+            args = [stack[i] for i in indices]
+
+            if func == self.add:
+                expr = self.flatten_add(args)
+            elif func == self.mul:
+                expr = self.flatten_mul(args)
+            elif func == self.pow and len(args) == 2:
+                expr = self.flatten_pow(args)
+            else:
+                expr = func(*args)
+
+            stack.append(expr)
+
+        return stack[-1]
+
+    def flatten(self, expr: Tree) -> Tree:
+        """Apply common ring simplification rules.
+
+        Identity (addition): :math:`x + 0 = x`
+        Identity (multiplication): :math:`x * 1 = x`
+        Associativity (addition): :math:`(x + y) + z = x + (y + z)`
+        Associativity (multiplication): :math:`(x * y) * z = x * (y * z)`
+        Commutativity (addition): :math:`x + y = y + x`
+        Commutativity (multiplication): :math:`x * y = y * x`
+        Add to Mul: :math:`2*x + 3*x = 5*x`
+        Mul to Pow: :math:`x^2 * x^3 = x^5`
+        ...
+        """
+        graph = forward_graph(expr)
+        stack = list(graph.atoms)
+        for func, indices in graph.operations:
+
+            args = [stack[i] for i in indices]
+
+            if func == self.add:
+                expr = self.flatten_add(args)
+            elif func == self.mul:
+                expr = self.flatten_mul(args)
+            elif func == self.pow and len(args) == 2:
+                expr = self.flatten_pow(args)
+            else:
+                expr = func(*args)
+
+            stack.append(expr)
+
+        return stack[-1]
 
 
 @dataclass(frozen=True)

--- a/src/protosym/core/sym.py
+++ b/src/protosym/core/sym.py
@@ -22,6 +22,7 @@ from weakref import WeakValueDictionary as _WeakDict
 from protosym.core.atom import AtomType
 from protosym.core.differentiate import diff_forward
 from protosym.core.differentiate import DiffProperties
+from protosym.core.differentiate import RingOps
 from protosym.core.evaluate import Evaluator
 from protosym.core.exceptions import BadRuleError
 from protosym.core.tree import SubsFunc
@@ -615,6 +616,26 @@ class SymEvaluator(Generic[T_sym, T_val]):
         if values is not None:
             values_rep = {e.rep: v for e, v in values.items()}
         return self.evaluator(expr.rep, values_rep)
+
+
+class SymRingOps(Generic[T_sym]):
+    """Representation of ring operations."""
+
+    def __init__(
+        self,
+        new_sym: Type[T_sym],
+        integer: SymAtomType[T_sym, int],
+        iadd: Callable[[int, int], int],
+        imul: Callable[[int, int], int],
+        add: Sym,
+        mul: Sym,
+        pow: Sym,
+    ):
+        self.new_sym = new_sym
+        self.ringops = RingOps(integer.atom_type, iadd, imul, add.rep, mul.rep, pow.rep)
+
+    def __call__(self, expr: T_sym) -> T_sym:
+        return self.new_sym(self.ringops.flatten(expr.rep))
 
 
 class SymDifferentiator(Generic[T_sym]):


### PR DESCRIPTION
CC @certik

Adds a flatten function method that can be used for common simplifications involving `Add`, `Mul`, `Pow` and `Integer`:
```python
In [19]: from protosym.simplecas import x, y, sin

In [20]: e = x + x + y*y + 2*sin(x) + 3*sin(x)

In [21]: e
Out[21]: ((((x + x) + (y*y)) + (2*sin(x))) + (3*sin(x)))

In [22]: e.flatten()
Out[22]: ((2*x) + y**2 + (5*sin(x)))
```
While I want to have a flatten function I don't want it to be used by default. While some of these simplifications are unambiguously good others are not which is why this sort of thing needs to be controlled.

The code implementing `flatten` is not great. I just put it together quickly while I think of a better way of structuring it.

The `flatten` function is used by default inside `diff` but can also be disabled:
```python
In [23]: sin(x).diff(x, 4)
Out[23]: sin(x)

In [24]: sin(x).diff(x, 4, flatten=False)
Out[24]: (-1*(-1*sin(x)))
```
I don't think I want this function to be used by default in `diff`. A much more limited version of this would be good because the current behaviour on main gives incorrect derivatives after a few rounds of differentiation:
```python
In [2]: from protosym.simplecas import x, y, sin

In [3]: (x**2).diff(x)
Out[3]: (2*x**(2 + -1))

In [4]: (x**2).diff(x, 2)
Out[4]: (2*((2 + -1)*x**((2 + -1) + -1)))

In [5]: (x**2).diff(x, 3)
Out[5]: (2*((2 + -1)*(((2 + -1) + -1)*x**(((2 + -1) + -1) + -1))))
```
All that is needed to fix that though is flattening an `Add` of only integers (constant folding) and applying `Pow(x, 1) -> x` (which is an unambiguously good simplification). Probably just a specialised derivative rule for `diff(x**2, x) -> Mul(2, x)` could do that. I think that I will try a more limited version of this PR that only has those two rules: constant folding and handling `x**2` better in differentiation.

This PR would fix that but also does too much:
```python
In [2]: (x**2).diff(x)
Out[2]: (2*x)

In [3]: (x**2).diff(x, 2)
Out[3]: 2

In [4]: (x**2).diff(x, 3)
Out[4]: 0
```
This makes this particular benchmark faster e.g. without main we have (not using rust_protosym):
```python
In [4]: from protosym.simplecas import x, y, sin

In [5]: %time ok = (x**10*sin(x)).diff(x, 100)
CPU times: user 3.08 s, sys: 2.16 ms, total: 3.08 s
Wall time: 3.08 s

In [6]: ok.count_ops_tree()
Out[6]: 3462587614523408610188244805484543

In [7]: ok.count_ops_graph()
Out[7]: 10506
```
However with this PR we have (not using rust_protosym):
```python
In [2]: %time ok = (x**10*sin(x)).diff(x, 100) # this can be made faster
CPU times: user 217 ms, sys: 0 ns, total: 217 ms
Wall time: 216 ms

In [3]: ok.count_ops_graph()
Out[3]: 43

In [4]: ok.count_ops_tree()
Out[4]: 72

In [5]: ok
Out[5]: ((-62815650955529472000*sin(x)) + (-6902818786321920000*x*cos(x)) + (337637875417920000*x**2*sin(x)) + (9681372771840000*x**3*cos(x)) + (-180238322880000*x**4*sin(x)) + (-2276694604800*x**5*cos(x)) + (19762974000*x**6*sin(x)) + (116424000*x**7*cos(x)) + (-445500*x**8*sin(x)) + (-1000*x**9*cos(x)) + (x**10*sin(x)))
```
In this example flattening is helpful because all derivatives of this expression can be reduced down. However this is not actually a common case in practice because it is a high order derivative of a simple expression that happens to simplify. The best algorithm for a case like this would be something specialised to high-order derivatives. In practice what we want from an efficient implementation of diff is mostly to be able to efficiently compute 1st and 2nd order derivatives of large expressions and in most cases the sort of reduction seen for high derivatives of `x**10*sin(x)` will not be seen.

The reason that I use benchmarks like `sin(sin(sin(sin(sin(sin(x)))))).diff(x, 10)` is that I know that the derivatives cannot simplify by much and so after a few iterations we will find ourselves necessarily find ourselves differentiating large expressions. What I want to benchmark is how performance scales for those large expressions.

The problem with the approach in this PR is that some of the rules applied by flatten increase the size of the expression graph:
```python
In [9]: e = sin(sin(sin(sin(sin(sin(x))))))

In [10]: e.diff(x, 5, flatten=True).count_ops_graph()
Out[10]: 563

In [11]: e.diff(x, 5, flatten=False).count_ops_graph()
Out[11]: 303

In [12]: e.diff(x, 5, flatten=True).count_ops_tree()
Out[12]: 21398

In [13]: e.diff(x, 5, flatten=False).count_ops_tree()
Out[13]: 79165
```
You can see here that the expression tree representation is made smaller by flattening but the expression graph representation is made larger. We generally want to work with the graph though because it is always smaller than the tree. These differences can all become more extreme:
```python
In [17]: e.diff(x, 10, flatten=False).count_ops_graph()
Out[17]: 1948

In [18]: e.diff(x, 10, flatten=True).count_ops_graph()
Out[18]: 89637

In [11]: e.diff(x, 10, flatten=False).count_ops_tree()
Out[11]: 3623428786

In [12]: e.diff(x, 10, flatten=True).count_ops_tree()
Out[12]: 3883153
```
There are various improvements that can be made to the flattening here. SymEngine's flattening actually computes a smaller derivative expression. The difference is most likely handling things like `a*b + b*a -> 2*a*b` which I haven't implemented here yet. These are the numbers for SymEngine's derivative of the above expression (after converting to protosym via SymPy which might have altered the expression):
```python
In [25]: e_sym = sympy.sympify(e_se)

In [26]: from protosym.simplecas import x, y, sin, Expr

In [27]: e_proto = Expr.from_sympy(e_sym)

In [28]: e_proto.count_ops_tree()
Out[28]: 375582

In [29]: e_proto.count_ops_graph()
Out[29]: 8697
```
We can see here that while SymEngine's derivative has a smaller tree representation it still has a larger graph representation than the derivative computed by protosym without flattening. What I want to do here is to shrink that graph representation by identifying precisely the right simplification rules and apply only those rules.